### PR TITLE
Improve generation workflow UI

### DIFF
--- a/src/components/LoadingIndicator.tsx
+++ b/src/components/LoadingIndicator.tsx
@@ -1,0 +1,54 @@
+interface LoadingIndicatorProps {
+  progress: number;
+  message: string;
+  history: string[];
+  isActive: boolean;
+}
+
+const LoadingIndicator = ({ progress, message, history, isActive }: LoadingIndicatorProps) => {
+  const clampedProgress = Math.min(100, Math.max(0, Math.round(progress)));
+
+  return (
+    <div className="rounded-xl border border-border/60 bg-card/50 backdrop-blur-sm p-4 space-y-4">
+      <div className="flex items-center justify-between text-sm text-muted-foreground">
+        <span>{message || "Prêt à lancer une nouvelle génération"}</span>
+        {isActive && <span className="font-medium text-foreground">{clampedProgress}%</span>}
+      </div>
+
+      {isActive && (
+        <div className="h-2 w-full overflow-hidden rounded-full bg-muted/40">
+          <div
+            className="h-full rounded-full bg-gradient-to-r from-primary via-secondary to-accent transition-all duration-500"
+            style={{ width: `${clampedProgress}%` }}
+          />
+        </div>
+      )}
+
+      {history.length > 0 && (
+        <ul className="space-y-2 text-sm">
+          {history.map((item, index) => {
+            const isLatest = index === history.length - 1;
+
+            return (
+              <li
+                key={`${item}-${index}`}
+                className={`flex items-start gap-2 ${
+                  isLatest ? "text-foreground" : "text-muted-foreground"
+                }`}
+              >
+                <span
+                  className={`mt-1 h-2 w-2 rounded-full ${
+                    isLatest ? "bg-primary" : "bg-muted-foreground/50"
+                  }`}
+                />
+                <span className="leading-snug">{item}</span>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default LoadingIndicator;

--- a/src/components/ResultDisplay.tsx
+++ b/src/components/ResultDisplay.tsx
@@ -1,6 +1,6 @@
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Download, Share2, Sparkles } from "lucide-react";
+import { Download, Sparkles } from "lucide-react";
 import CodeViewer from "./CodeViewer";
 
 interface ResultDisplayProps {
@@ -28,7 +28,7 @@ const ResultDisplay = ({ result }: ResultDisplayProps) => {
   };
 
   return (
-    <Card className="w-full max-w-4xl mx-auto bg-card/50 backdrop-blur-sm border-border/50 overflow-hidden">
+    <Card className="w-full bg-card/50 backdrop-blur-sm border-border/50 overflow-hidden">
       <div className="p-6 space-y-4">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- keep the prompt chat pane visible next to the result preview so users can request follow-up changes without leaving the generated output
- add a dedicated loading indicator component that streams progress messages while a generation request is running and surfaces errors
- adjust the result card styling to better fit the new split layout

## Testing
- npm run lint *(fails: existing lint violations in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68dca2228f9883238bab108b49d04c1d