### PR TITLE
Add refinement workflow for generated content

### DIFF
--- a/src/components/PromptInput.tsx
+++ b/src/components/PromptInput.tsx
@@ -1,16 +1,33 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import type { KeyboardEvent } from "react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Sparkles } from "lucide-react";
+import type { GeneratedResult } from "@/types/result";
 
 interface PromptInputProps {
   onSubmit: (prompt: string) => void;
+  onRefineSubmit?: (modification: string) => void;
   isLoading: boolean;
   selectedCategory: string;
+  hasResult?: boolean;
+  history?: GeneratedResult[];
 }
 
-const PromptInput = ({ onSubmit, isLoading, selectedCategory }: PromptInputProps) => {
+const PromptInput = ({
+  onSubmit,
+  onRefineSubmit,
+  isLoading,
+  selectedCategory,
+  hasResult,
+  history = [],
+}: PromptInputProps) => {
   const [prompt, setPrompt] = useState("");
+  const [modification, setModification] = useState("");
+
+  useEffect(() => {
+    setModification("");
+  }, [history]);
 
   const handleSubmit = () => {
     if (prompt.trim()) {
@@ -18,15 +35,28 @@ const PromptInput = ({ onSubmit, isLoading, selectedCategory }: PromptInputProps
     }
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
+  const handleRefine = () => {
+    if (modification.trim() && onRefineSubmit) {
+      onRefineSubmit(modification.trim());
+    }
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
       handleSubmit();
     }
   };
 
+  const handleModificationKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleRefine();
+    }
+  };
+
   return (
-    <div className="w-full max-w-4xl mx-auto space-y-4">
+    <div className="w-full max-w-4xl mx-auto space-y-6">
       <div className="relative">
         <Textarea
           value={prompt}
@@ -52,6 +82,88 @@ const PromptInput = ({ onSubmit, isLoading, selectedCategory }: PromptInputProps
         <Sparkles className="mr-2 h-5 w-5" />
         {isLoading ? "Création en cours..." : "Créer avec l'IA"}
       </Button>
+
+      {hasResult && onRefineSubmit && (
+        <div className="space-y-3 rounded-xl border border-border/60 bg-card/40 p-4">
+          <div>
+            <p className="text-sm font-medium">Demander une modification</p>
+            <p className="text-xs text-muted-foreground">
+              Décrivez les ajustements à appliquer sur le contenu généré sans repartir de zéro.
+            </p>
+          </div>
+          <Textarea
+            value={modification}
+            onChange={(e) => setModification(e.target.value)}
+            onKeyDown={handleModificationKeyDown}
+            placeholder="Précisez les améliorations ou corrections souhaitées..."
+            className="min-h-[100px] bg-background/60 border-border/50 focus:border-secondary/60 text-sm"
+            disabled={isLoading}
+          />
+          <Button
+            variant="outline"
+            onClick={handleRefine}
+            disabled={isLoading || !modification.trim()}
+            className="w-full border-secondary/40 text-secondary hover:bg-secondary/10"
+          >
+            Soumettre la modification
+          </Button>
+
+          {history.length > 0 && (
+            <div className="space-y-2 pt-2 border-t border-border/40">
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Historique des versions
+              </p>
+              <div className="space-y-2 max-h-48 overflow-y-auto pr-1">
+                {history.map((entry) => (
+                  <div
+                    key={entry.version}
+                    className="rounded-lg border border-border/40 bg-background/60 p-3 space-y-2"
+                  >
+                    <div className="flex items-center justify-between text-xs text-muted-foreground">
+                      <span>Version {entry.version}</span>
+                      <span>{entry.version === 1 ? "Initiale" : "Révision"}</span>
+                    </div>
+                    <div className="space-y-1 text-xs text-muted-foreground">
+                      <p>
+                        <span className="font-medium text-foreground">Prompt :</span>{" "}
+                        {entry.prompt}
+                      </p>
+                      {entry.modification && (
+                        <p>
+                          <span className="font-medium text-foreground">Modification :</span>{" "}
+                          {entry.modification}
+                        </p>
+                      )}
+                    </div>
+                    <div className="flex flex-wrap gap-2">
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="secondary"
+                        onClick={() => setPrompt(entry.prompt)}
+                        className="text-xs"
+                      >
+                        Réutiliser le prompt
+                      </Button>
+                      {entry.modification && (
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="secondary"
+                          onClick={() => setModification(entry.modification ?? "")}
+                          className="text-xs"
+                        >
+                          Réutiliser la modification
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/ResultDisplay.tsx
+++ b/src/components/ResultDisplay.tsx
@@ -2,18 +2,56 @@ import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Download, Sparkles } from "lucide-react";
 import CodeViewer from "./CodeViewer";
+import type { GeneratedResult } from "@/types/result";
 
 interface ResultDisplayProps {
-  result: {
-    type: string;
-    category: string;
-    content: string;
-    preview?: string;
-    code?: string;
-  } | null;
+  result: GeneratedResult | null;
+  history: GeneratedResult[];
 }
 
-const ResultDisplay = ({ result }: ResultDisplayProps) => {
+const summarize = (text: string, maxLength = 80) =>
+  text.length > maxLength ? `${text.slice(0, maxLength - 1)}…` : text;
+
+const renderResultContent = (entry: GeneratedResult) => {
+  if (entry.type === 'image' && entry.preview) {
+    return (
+      <div className="flex items-center justify-center min-h-[300px]">
+        <img
+          src={entry.preview}
+          alt="Résultat"
+          className="max-w-full max-h-[500px] object-contain rounded-lg"
+        />
+      </div>
+    );
+  }
+
+  if (entry.type === 'code' && entry.code) {
+    return <CodeViewer code={entry.code} category={entry.category} />;
+  }
+
+  if (entry.type === 'description') {
+    return (
+      <div className="prose prose-invert max-w-none">
+        <div className="whitespace-pre-wrap text-foreground leading-relaxed">
+          {entry.content}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="text-center space-y-4 min-h-[300px] flex flex-col items-center justify-center">
+      <div className="inline-block p-4 rounded-full bg-gradient-to-br from-primary/20 to-secondary/20">
+        <Sparkles className="h-12 w-12 text-primary" />
+      </div>
+      <p className="text-muted-foreground max-w-md">
+        {entry.content}
+      </p>
+    </div>
+  );
+};
+
+const ResultDisplay = ({ result, history }: ResultDisplayProps) => {
   if (!result) return null;
 
   const handleDownloadImage = () => {
@@ -30,16 +68,28 @@ const ResultDisplay = ({ result }: ResultDisplayProps) => {
   return (
     <Card className="w-full bg-card/50 backdrop-blur-sm border-border/50 overflow-hidden">
       <div className="p-6 space-y-4">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <Sparkles className="h-5 w-5 text-primary" />
-            <h3 className="text-xl font-semibold">Votre création</h3>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-1">
+            <div className="flex items-center gap-2">
+              <Sparkles className="h-5 w-5 text-primary" />
+              <h3 className="text-xl font-semibold">
+                Votre création{result.version > 1 ? ` · Révision ${result.version}` : ''}
+              </h3>
+            </div>
+            <p className="text-sm text-muted-foreground">
+              Prompt initial : {result.prompt}
+            </p>
+            {result.modification && (
+              <p className="text-xs text-muted-foreground">
+                Dernière demande : {result.modification}
+              </p>
+            )}
           </div>
-          
+
           {result.type === 'image' && (
             <div className="flex gap-2">
-              <Button 
-                variant="outline" 
+              <Button
+                variant="outline"
                 size="sm" 
                 className="border-border/50 hover:border-primary/50"
                 onClick={handleDownloadImage}
@@ -52,33 +102,45 @@ const ResultDisplay = ({ result }: ResultDisplayProps) => {
         </div>
 
         <div className="rounded-lg bg-background/50 p-4">
-          {result.type === 'image' && result.preview ? (
-            <div className="flex items-center justify-center min-h-[300px]">
-              <img 
-                src={result.preview} 
-                alt="Résultat" 
-                className="max-w-full max-h-[500px] object-contain rounded-lg"
-              />
-            </div>
-          ) : result.type === 'code' && result.code ? (
-            <CodeViewer code={result.code} category={result.category} />
-          ) : result.type === 'description' ? (
-            <div className="prose prose-invert max-w-none">
-              <div className="whitespace-pre-wrap text-foreground leading-relaxed">
-                {result.content}
-              </div>
-            </div>
-          ) : (
-            <div className="text-center space-y-4 min-h-[300px] flex flex-col items-center justify-center">
-              <div className="inline-block p-4 rounded-full bg-gradient-to-br from-primary/20 to-secondary/20">
-                <Sparkles className="h-12 w-12 text-primary" />
-              </div>
-              <p className="text-muted-foreground max-w-md">
-                {result.content}
-              </p>
-            </div>
-          )}
+          {renderResultContent(result)}
         </div>
+
+        {history.length > 1 && (
+          <div className="space-y-3 pt-4 border-t border-border/40">
+            <p className="text-sm font-semibold text-foreground">Historique des versions</p>
+            <div className="space-y-2">
+              {history
+                .filter((entry) => entry.version !== result.version)
+                .map((entry) => (
+                  <details
+                    key={entry.version}
+                    className="rounded-lg border border-border/40 bg-background/40"
+                  >
+                    <summary
+                      className="cursor-pointer select-none px-4 py-2 text-sm font-medium text-foreground"
+                      title={entry.modification || undefined}
+                    >
+                      Version {entry.version} {entry.version === 1 ? '(initiale)' : ''}
+                      {entry.modification ? ` · ${summarize(entry.modification)}` : ''}
+                    </summary>
+                    <div className="space-y-3 px-4 pb-4 pt-2 text-sm text-muted-foreground">
+                      <p className="whitespace-pre-wrap">
+                        <span className="font-semibold text-foreground">Prompt :</span> {entry.prompt}
+                      </p>
+                      {entry.modification && (
+                        <p>
+                          <span className="font-semibold text-foreground">Demande :</span> {entry.modification}
+                        </p>
+                      )}
+                      <div className="rounded-lg bg-background/60 p-3">
+                        {renderResultContent(entry)}
+                      </div>
+                    </div>
+                  </details>
+                ))}
+            </div>
+          </div>
+        )}
       </div>
     </Card>
   );

--- a/src/types/result.ts
+++ b/src/types/result.ts
@@ -1,0 +1,10 @@
+export interface GeneratedResult {
+  type: string;
+  category: string;
+  content: string;
+  preview?: string;
+  code?: string;
+  prompt: string;
+  version: number;
+  modification?: string;
+}


### PR DESCRIPTION
## Summary
- add refinement handling on the index page, preserving the latest result while tracking previous versions
- extend the prompt input to capture revision requests and surface prior prompts/modifications for reuse
- adjust the Supabase function to forward modification context so Lovable can update existing content

## Testing
- npm run lint *(fails due to pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dca7dd04348323b98ef0ab624fce7a