### PR TITLE
feat: support resizable generation window and react website output

### DIFF
--- a/src/components/CodeViewer.tsx
+++ b/src/components/CodeViewer.tsx
@@ -35,11 +35,11 @@ const CodeViewer = ({ code, category }: CodeViewerProps) => {
       case 'game':
         zip.file("index.html", code);
         break;
-      case 'app':
+      case 'app': {
         // Extraire le JSX et le CSS si possible
         const jsxMatch = code.match(/<!-- App\.jsx -->([\s\S]*?)<!-- App\.css -->/);
         const cssMatch = code.match(/<!-- App\.css -->([\s\S]*?)$/);
-        
+
         if (jsxMatch) {
           zip.file("App.jsx", jsxMatch[1].trim());
         }
@@ -49,7 +49,7 @@ const CodeViewer = ({ code, category }: CodeViewerProps) => {
         if (!jsxMatch && !cssMatch) {
           zip.file("App.jsx", code);
         }
-        
+
         // Ajouter le package.json
         zip.file("package.json", JSON.stringify({
           name: "generated-app",
@@ -60,6 +60,7 @@ const CodeViewer = ({ code, category }: CodeViewerProps) => {
           }
         }, null, 2));
         break;
+      }
       case 'agent':
         zip.file("agent.py", code);
         zip.file("requirements.txt", "requests\npython-dotenv");
@@ -117,27 +118,31 @@ const CodeViewer = ({ code, category }: CodeViewerProps) => {
 
       {viewMode === 'code' ? (
         <div className="rounded-lg overflow-hidden border border-border/50">
-          <SyntaxHighlighter
-            language={getLanguage()}
-            style={vscDarkPlus}
-            customStyle={{
-              margin: 0,
-              maxHeight: '500px',
-              fontSize: '14px'
-            }}
-            showLineNumbers
-          >
-            {code}
-          </SyntaxHighlighter>
+          <div className="resize-y overflow-auto" style={{ minHeight: '280px', maxHeight: '80vh' }}>
+            <SyntaxHighlighter
+              language={getLanguage()}
+              style={vscDarkPlus}
+              customStyle={{
+                margin: 0,
+                background: 'transparent',
+                fontSize: '14px'
+              }}
+              showLineNumbers
+            >
+              {code}
+            </SyntaxHighlighter>
+          </div>
         </div>
       ) : (
         <div className="rounded-lg overflow-hidden border border-border/50 bg-white">
-          <iframe
-            srcDoc={code}
-            className="w-full h-[500px]"
-            title="Preview"
-            sandbox="allow-scripts allow-same-origin"
-          />
+          <div className="resize-y overflow-auto" style={{ minHeight: '280px', maxHeight: '80vh' }}>
+            <iframe
+              srcDoc={code}
+              className="h-full min-h-[280px] w-full"
+              title="Preview"
+              sandbox="allow-scripts allow-same-origin"
+            />
+          </div>
         </div>
       )}
     </div>

--- a/src/components/ReactProjectViewer.tsx
+++ b/src/components/ReactProjectViewer.tsx
@@ -244,13 +244,18 @@ const ReactProjectViewer = ({ files, instructions, projectName }: ReactProjectVi
             Télécharger
           </Button>
         </div>
-        <ScrollArea className="h-[320px]">
-          <div className="space-y-1 px-2 py-3">
-            {fileTree.length ? renderTree(fileTree) : (
-              <p className="px-3 text-sm text-muted-foreground">Aucun fichier disponible.</p>
-            )}
-          </div>
-        </ScrollArea>
+        <div
+          className="resize-y overflow-hidden"
+          style={{ minHeight: '240px', maxHeight: '70vh', height: '320px' }}
+        >
+          <ScrollArea className="h-full">
+            <div className="space-y-1 px-2 py-3">
+              {fileTree.length ? renderTree(fileTree) : (
+                <p className="px-3 text-sm text-muted-foreground">Aucun fichier disponible.</p>
+              )}
+            </div>
+          </ScrollArea>
+        </div>
       </div>
 
       <div className="space-y-4">
@@ -269,7 +274,10 @@ const ReactProjectViewer = ({ files, instructions, projectName }: ReactProjectVi
               {activeFile || 'Sélectionnez un fichier pour afficher son contenu'}
             </p>
           </div>
-          <div className="max-h-[420px] overflow-auto">
+          <div
+            className="resize-y overflow-auto"
+            style={{ minHeight: '320px', maxHeight: '80vh' }}
+          >
             {activeFileContent ? (
               <SyntaxHighlighter
                 language={activeLanguage}


### PR DESCRIPTION
## Summary
- allow resizing of the generated code and preview panes so users can expand them as needed
- request full React/Vite project structures for website generations and surface parsed project metadata in the response

## Testing
- npm run lint *(fails: existing lint errors in shared ui files and tailwind config)*

------
https://chatgpt.com/codex/tasks/task_e_68dcb6dfb8ec8323914da953fea8b630