### PR TITLE
Fix tooltip fragment usage in chart component

### DIFF
--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -176,7 +176,7 @@ const ChartTooltipContent = React.forwardRef<
                 {formatter && item?.value !== undefined && item.name ? (
                   formatter(item.value, item.name, item, index, item.payload)
                 ) : (
-                  <>
+                  <React.Fragment>
                     {itemConfig?.icon ? (
                       <itemConfig.icon />
                     ) : (
@@ -213,7 +213,7 @@ const ChartTooltipContent = React.forwardRef<
                         </span>
                       )}
                     </div>
-                  </>
+                  </React.Fragment>
                 )}
               </div>
             );


### PR DESCRIPTION
## Summary
- replace shorthand fragments in the chart tooltip with `React.Fragment` to improve compatibility with environments lacking JSX fragment support

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcbc8582f88323860b252a51838e2e