### PR TITLE
feat: add contextual visual editor overlay

### DIFF
--- a/src/components/CodeViewer.tsx
+++ b/src/components/CodeViewer.tsx
@@ -1,17 +1,45 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import type { FormEvent } from "react";
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { vscDarkPlus } from 'react-syntax-highlighter/dist/esm/styles/prism';
 import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
 import { Code2, Eye, Download } from "lucide-react";
 import JSZip from "jszip";
+import type { ContextualEditPayload } from "@/types/editor";
 
 interface CodeViewerProps {
   code: string;
   category: string;
+  onContextEdit?: (payload: ContextualEditPayload) => void;
 }
 
-const CodeViewer = ({ code, category }: CodeViewerProps) => {
+interface SelectedElementState {
+  targetSelector: string;
+  textContent: string;
+  outerHTML: string;
+  highlightBox: {
+    top: number;
+    left: number;
+    width: number;
+    height: number;
+  };
+  editorPosition: {
+    top: number;
+    left: number;
+  };
+}
+
+const overlayWidth = 280;
+const estimatedOverlayHeight = 220;
+
+const CodeViewer = ({ code, category, onContextEdit }: CodeViewerProps) => {
   const [viewMode, setViewMode] = useState<'code' | 'preview'>('code');
+  const [selectedElement, setSelectedElement] = useState<SelectedElementState | null>(null);
+  const [contextInstruction, setContextInstruction] = useState("");
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+  const previewContainerRef = useRef<HTMLDivElement | null>(null);
+  const instructionRef = useRef<HTMLTextAreaElement | null>(null);
 
   const getLanguage = () => {
     switch (category) {
@@ -80,6 +108,153 @@ const CodeViewer = ({ code, category }: CodeViewerProps) => {
 
   const canPreview = category === 'website' || category === 'game';
 
+  const buildSelector = (element: HTMLElement) => {
+    const tag = element.tagName.toLowerCase();
+    const id = element.id ? `#${element.id}` : '';
+    const classSelector = element.classList.length
+      ? `.${Array.from(element.classList).join('.')}`
+      : '';
+
+    return `${tag}${id}${classSelector}`;
+  };
+
+  const resetSelection = () => {
+    setSelectedElement(null);
+    setContextInstruction("");
+  };
+
+  useEffect(() => {
+    if (viewMode !== 'preview' || !onContextEdit) {
+      resetSelection();
+      return;
+    }
+
+    const iframe = iframeRef.current;
+    if (!iframe) return;
+
+    let cleanupDoc: (() => void) | undefined;
+
+    const attachListeners = () => {
+      const doc = iframe.contentDocument;
+      const container = previewContainerRef.current;
+
+      if (!doc || !container) {
+        return;
+      }
+
+      const originalCursor = doc.body?.style.cursor;
+
+      const handleClick = (event: MouseEvent) => {
+        if (!onContextEdit) return;
+
+        event.preventDefault();
+        event.stopPropagation();
+
+        const target = event.target as HTMLElement | null;
+        if (!target) return;
+
+        const containerRect = container.getBoundingClientRect();
+        const iframeRect = iframe.getBoundingClientRect();
+        const targetRect = target.getBoundingClientRect();
+
+        const baseTop = targetRect.top + iframeRect.top - containerRect.top + container.scrollTop;
+        const baseLeft = targetRect.left + iframeRect.left - containerRect.left + container.scrollLeft;
+
+        const containerWidth = container.clientWidth;
+        const containerHeight = container.clientHeight;
+
+        const belowTop = baseTop + targetRect.height + 8;
+        const fitsBelow = belowTop + estimatedOverlayHeight <= containerHeight;
+        const editorTop = fitsBelow ? belowTop : Math.max(8, baseTop - estimatedOverlayHeight - 8);
+
+        const maxLeft = Math.max(8, containerWidth - overlayWidth - 8);
+        const editorLeft = Math.min(Math.max(8, baseLeft), maxLeft);
+
+        setSelectedElement({
+          targetSelector: buildSelector(target),
+          textContent: target.textContent?.trim().slice(0, 160) ?? '',
+          outerHTML: target.outerHTML,
+          highlightBox: {
+            top: Math.max(0, baseTop - 2),
+            left: Math.max(0, baseLeft - 2),
+            width: targetRect.width + 4,
+            height: targetRect.height + 4,
+          },
+          editorPosition: {
+            top: editorTop,
+            left: editorLeft,
+          },
+        });
+        setContextInstruction("");
+      };
+
+      doc.addEventListener('click', handleClick, true);
+      if (doc.body) {
+        doc.body.style.cursor = 'pointer';
+      }
+
+      cleanupDoc = () => {
+        doc.removeEventListener('click', handleClick, true);
+        if (doc.body) {
+          doc.body.style.cursor = originalCursor || '';
+        }
+      };
+    };
+
+    if (iframe.contentDocument?.readyState === 'complete' || iframe.contentDocument?.readyState === 'interactive') {
+      attachListeners();
+    }
+
+    iframe.addEventListener('load', attachListeners);
+
+    return () => {
+      iframe.removeEventListener('load', attachListeners);
+      cleanupDoc?.();
+    };
+  }, [viewMode, code, onContextEdit]);
+
+  useEffect(() => {
+    if (selectedElement && instructionRef.current) {
+      instructionRef.current.focus();
+    }
+  }, [selectedElement]);
+
+  const handleContextSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    if (!selectedElement || !onContextEdit || !contextInstruction.trim()) {
+      return;
+    }
+
+    const payload: ContextualEditPayload = {
+      targetSelector: selectedElement.targetSelector,
+      textContent: selectedElement.textContent,
+      outerHTML: selectedElement.outerHTML,
+      instruction: contextInstruction.trim(),
+    };
+
+    onContextEdit(payload);
+    resetSelection();
+  };
+
+  useEffect(() => {
+    if (!selectedElement) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        resetSelection();
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [selectedElement]);
+
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
@@ -134,14 +309,69 @@ const CodeViewer = ({ code, category }: CodeViewerProps) => {
           </div>
         </div>
       ) : (
-        <div className="rounded-lg overflow-hidden border border-border/50 bg-white">
-          <div className="resize-y overflow-auto" style={{ minHeight: '280px', maxHeight: '80vh' }}>
+        <div className="rounded-lg border border-border/50 bg-white">
+          <div
+            ref={previewContainerRef}
+            className="relative resize-y overflow-auto"
+            style={{ minHeight: '280px', maxHeight: '80vh' }}
+          >
+            {onContextEdit && (
+              <div className="absolute left-3 top-3 z-10 rounded-md bg-black/70 px-3 py-1 text-xs font-medium text-white">
+                Cliquez sur un élément pour le modifier
+              </div>
+            )}
             <iframe
+              ref={iframeRef}
               srcDoc={code}
               className="h-full min-h-[280px] w-full"
               title="Preview"
               sandbox="allow-scripts allow-same-origin"
             />
+            {selectedElement && (
+              <>
+                <div
+                  className="pointer-events-none absolute z-20 rounded-md border-2 border-primary/80 shadow-[0_0_0_2px_rgba(12,10,9,0.4)]"
+                  style={{
+                    top: `${selectedElement.highlightBox.top}px`,
+                    left: `${selectedElement.highlightBox.left}px`,
+                    width: `${selectedElement.highlightBox.width}px`,
+                    height: `${selectedElement.highlightBox.height}px`,
+                  }}
+                />
+                <form
+                  onSubmit={handleContextSubmit}
+                  className="absolute z-30 w-[280px] rounded-md border border-border/80 bg-background/95 p-3 shadow-xl backdrop-blur"
+                  style={{
+                    top: `${selectedElement.editorPosition.top}px`,
+                    left: `${selectedElement.editorPosition.left}px`,
+                  }}
+                >
+                  <p className="text-xs font-semibold text-foreground">
+                    Élément sélectionné : {selectedElement.targetSelector}
+                  </p>
+                  {selectedElement.textContent && (
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      Contenu actuel : {selectedElement.textContent}
+                    </p>
+                  )}
+                  <Textarea
+                    ref={instructionRef}
+                    value={contextInstruction}
+                    onChange={(event) => setContextInstruction(event.target.value)}
+                    placeholder="Décrivez la modification souhaitée"
+                    className="mt-3 h-24 text-sm"
+                  />
+                  <div className="mt-3 flex items-center justify-end gap-2">
+                    <Button type="button" variant="ghost" size="sm" onClick={resetSelection}>
+                      Annuler
+                    </Button>
+                    <Button type="submit" size="sm" disabled={!contextInstruction.trim()}>
+                      Appliquer
+                    </Button>
+                  </div>
+                </form>
+              </>
+            )}
           </div>
         </div>
       )}

--- a/src/components/ResultDisplay.tsx
+++ b/src/components/ResultDisplay.tsx
@@ -4,16 +4,23 @@ import { Download, Sparkles } from "lucide-react";
 import CodeViewer from "./CodeViewer";
 import ReactProjectViewer from "./ReactProjectViewer";
 import type { GeneratedResult } from "@/types/result";
+import type { ContextualEditPayload } from "@/types/editor";
 
 interface ResultDisplayProps {
   result: GeneratedResult | null;
   history: GeneratedResult[];
+  onContextEdit?: (payload: ContextualEditPayload) => void;
 }
 
 const summarize = (text: string, maxLength = 80) =>
   text.length > maxLength ? `${text.slice(0, maxLength - 1)}…` : text;
 
-const renderResultContent = (entry: GeneratedResult) => {
+interface RenderOptions {
+  enableVisualEditing?: boolean;
+  onContextEdit?: (payload: ContextualEditPayload) => void;
+}
+
+const renderResultContent = (entry: GeneratedResult, options?: RenderOptions) => {
   if (entry.type === 'image' && entry.preview) {
     return (
       <div className="flex items-center justify-center min-h-[300px]">
@@ -37,7 +44,13 @@ const renderResultContent = (entry: GeneratedResult) => {
   }
 
   if (entry.type === 'code' && entry.code) {
-    return <CodeViewer code={entry.code} category={entry.category} />;
+    return (
+      <CodeViewer
+        code={entry.code}
+        category={entry.category}
+        onContextEdit={options?.enableVisualEditing ? options?.onContextEdit : undefined}
+      />
+    );
   }
 
   if (entry.type === 'description') {
@@ -62,7 +75,7 @@ const renderResultContent = (entry: GeneratedResult) => {
   );
 };
 
-const ResultDisplay = ({ result, history }: ResultDisplayProps) => {
+const ResultDisplay = ({ result, history, onContextEdit }: ResultDisplayProps) => {
   if (!result) return null;
 
   const handleDownloadImage = () => {
@@ -113,7 +126,7 @@ const ResultDisplay = ({ result, history }: ResultDisplayProps) => {
         </div>
 
         <div className="rounded-lg bg-background/50 p-4">
-          {renderResultContent(result)}
+          {renderResultContent(result, { enableVisualEditing: true, onContextEdit })}
         </div>
 
         {history.length > 1 && (

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -15,6 +15,7 @@ import { supabase } from "@/integrations/supabase/client";
 import { Card } from "@/components/ui/card";
 import { Sparkles } from "lucide-react";
 import type { GeneratedFile, GeneratedResult } from "@/types/result";
+import type { ContextualEditPayload } from "@/types/editor";
 
 const loadingSteps = [
   "Analyse du prompt et compréhension du contexte",
@@ -293,6 +294,21 @@ const Index = () => {
     }
   };
 
+  const handleContextualEdit = (payload: ContextualEditPayload) => {
+    const details = [`Cible sélectionnée : ${payload.targetSelector}`];
+
+    if (payload.textContent) {
+      details.push(`Texte actuel : "${payload.textContent}"`);
+    }
+
+    const contextualInstruction = `${details.join('\n')}`.concat(
+      `\n\nInstruction : ${payload.instruction}`,
+      `\n\nHTML actuel :\n${payload.outerHTML}`,
+    );
+
+    return handleRefineSubmit(contextualInstruction);
+  };
+
   useEffect(() => {
     let stepIndex = 0;
     let interval: ReturnType<typeof setInterval> | undefined;
@@ -433,7 +449,11 @@ const Index = () => {
 
             <div className="w-full">
               {result ? (
-                <ResultDisplay result={result} history={resultHistory} />
+                <ResultDisplay
+                  result={result}
+                  history={resultHistory}
+                  onContextEdit={handleContextualEdit}
+                />
               ) : (
                 <Card className="h-full min-h-[420px] w-full border-dashed border-border/60 bg-card/30">
                   <div className="flex h-full flex-col items-center justify-center space-y-4 p-8 text-center">

--- a/src/types/editor.ts
+++ b/src/types/editor.ts
@@ -1,0 +1,6 @@
+export interface ContextualEditPayload {
+  targetSelector: string;
+  textContent?: string;
+  outerHTML: string;
+  instruction: string;
+}


### PR DESCRIPTION
## Summary
- add a contextual editing overlay to the HTML preview so users can select elements and submit targeted instructions
- wire the contextual edit requests through the result display to the existing refine flow
- define a shared payload interface for contextual edits

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcbe32c02c83238979b43b0717b8a5