### PR TITLE
Add multi-generator workspace and creative tools

### DIFF
--- a/src/components/CreativeGenerator.tsx
+++ b/src/components/CreativeGenerator.tsx
@@ -1,0 +1,110 @@
+import { useCallback, useMemo, useState } from "react";
+import { toast } from "sonner";
+
+import PromptInput from "@/components/PromptInput";
+import ResultDisplay from "@/components/ResultDisplay";
+import type { GeneratedResult } from "@/types/result";
+import {
+  generateCreativeResult,
+  getCreativeToolLabel,
+  type CreativeTool,
+} from "@/lib/content-generators";
+
+interface CreativeGeneratorProps {
+  tool: CreativeTool;
+  description: string;
+}
+
+const CreativeGenerator = ({ tool, description }: CreativeGeneratorProps) => {
+  const [history, setHistory] = useState<GeneratedResult[]>([]);
+  const [result, setResult] = useState<GeneratedResult | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [lastPrompt, setLastPrompt] = useState("");
+
+  const label = useMemo(() => getCreativeToolLabel(tool), [tool]);
+
+  const handleSubmit = useCallback(
+    (prompt: string) => {
+      if (!prompt.trim()) {
+        toast.error("Décris ce que tu souhaites générer avant de lancer l'outil.");
+        return;
+      }
+
+      try {
+        setIsLoading(true);
+        const version = history.length + 1;
+        const generated = generateCreativeResult(tool, {
+          prompt,
+          version,
+          previous: result,
+        });
+        setHistory((previous) => [...previous, generated]);
+        setResult(generated);
+        setLastPrompt(prompt);
+        toast.success("Création générée !");
+      } catch (error) {
+        console.error("Erreur pendant la génération", error);
+        toast.error("Impossible de créer ce contenu pour le moment.");
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [history.length, result, tool],
+  );
+
+  const handleRefineSubmit = useCallback(
+    (modification: string) => {
+      if (!result) return;
+      if (!modification.trim()) {
+        toast.error("Décris l'ajustement souhaité avant de lancer une révision.");
+        return;
+      }
+
+      try {
+        setIsLoading(true);
+        const version = history.length + 1;
+        const generated = generateCreativeResult(tool, {
+          prompt: lastPrompt || result.prompt,
+          version,
+          modification,
+          previous: result,
+        });
+        setHistory((previous) => [...previous, generated]);
+        setResult(generated);
+        toast.success("Révision générée !");
+      } catch (error) {
+        console.error("Erreur pendant la révision", error);
+        toast.error("Impossible d'appliquer cette modification.");
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [history.length, lastPrompt, result, tool],
+  );
+
+  return (
+    <div className="flex h-full flex-col bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950">
+      <div className="border-b border-white/5 px-6 py-4">
+        <h3 className="text-lg font-semibold text-white">{label}</h3>
+        <p className="mt-1 text-sm text-slate-300/80">{description}</p>
+      </div>
+
+      <div className="flex-1 overflow-y-auto px-6 py-6">
+        <div className="mx-auto flex max-w-5xl flex-col gap-6">
+          <PromptInput
+            onSubmit={handleSubmit}
+            onRefineSubmit={handleRefineSubmit}
+            isLoading={isLoading}
+            selectedCategory={label}
+            hasResult={Boolean(result)}
+            history={history}
+          />
+
+          <ResultDisplay result={result} history={history} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CreativeGenerator;

--- a/src/components/PromptSidebar.tsx
+++ b/src/components/PromptSidebar.tsx
@@ -15,6 +15,13 @@ interface PromptSidebarProps {
   canExport: boolean;
   projectName?: string;
   instructions?: string;
+  title?: string;
+  description?: string;
+  promptLabel?: string;
+  promptPlaceholder?: string;
+  hints?: string[];
+  generateLabel?: string;
+  exportLabel?: string;
 }
 
 const PromptSidebar = ({
@@ -27,15 +34,23 @@ const PromptSidebar = ({
   canExport,
   projectName,
   instructions,
+  title = "Générateur",
+  description = "Décris le site ou l'application que tu souhaites. Utilise <code>Nom: ...</code> pour nommer le projet.",
+  promptLabel = "Prompt",
+  promptPlaceholder = "Landing page\nNom: Mon Super Site\nBouton vert",
+  hints,
+  generateLabel = "Générer le projet",
+  exportLabel = "Exporter en .zip",
 }: PromptSidebarProps) => {
-  const hints = useMemo(
-    () => [
-      "Landing page moderne",
-      "Nom: Mon Super Site",
-      "Ajoute un bouton vert",
-      "Page d'accueil minimaliste",
-    ],
-    [],
+  const suggestions = useMemo(
+    () =>
+      hints ?? [
+        "Landing page moderne",
+        "Nom: Mon Super Site",
+        "Ajoute un bouton vert",
+        "Page d'accueil minimaliste",
+      ],
+    [hints],
   );
 
   return (
@@ -43,27 +58,27 @@ const PromptSidebar = ({
       <div className="border-b border-border/40 px-5 py-4">
         <div className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wider text-muted-foreground">
           <Sparkles className="h-4 w-4" />
-          Générateur
+          {title}
         </div>
         <p className="mt-2 text-sm text-muted-foreground/80">
-          Décris le site ou l'application que tu souhaites. Utilise <code>Nom: ...</code> pour nommer le projet.
+          <span dangerouslySetInnerHTML={{ __html: description }} />
         </p>
       </div>
 
       <div className="flex-1 space-y-5 overflow-hidden p-5">
         <div className="space-y-3">
           <label htmlFor="prompt" className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
-            Prompt
+            {promptLabel}
           </label>
           <Textarea
             id="prompt"
             value={prompt}
             onChange={(event) => onPromptChange(event.target.value)}
             className="min-h-[220px] resize-none"
-            placeholder={"Landing page\nNom: Mon Super Site\nBouton vert"}
+            placeholder={promptPlaceholder}
           />
           <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
-            {hints.map((hint) => (
+            {suggestions.map((hint) => (
               <span
                 key={hint}
                 className="rounded-full border border-border/60 px-3 py-1"
@@ -76,7 +91,7 @@ const PromptSidebar = ({
 
         <div className="flex flex-col gap-2">
           <Button onClick={onGenerate} disabled={isGenerating} className="w-full">
-            {isGenerating ? "Génération…" : "Générer le projet"}
+            {isGenerating ? "Génération…" : generateLabel}
           </Button>
           <Button
             onClick={onExport}
@@ -85,7 +100,7 @@ const PromptSidebar = ({
             className="w-full gap-2"
           >
             <Download className="h-4 w-4" />
-            {isExporting ? "Export en cours…" : "Exporter en .zip"}
+            {isExporting ? "Export en cours…" : exportLabel}
           </Button>
         </div>
 

--- a/src/components/SiteAppGenerator.tsx
+++ b/src/components/SiteAppGenerator.tsx
@@ -1,0 +1,170 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import JSZip from "jszip";
+import { toast } from "sonner";
+
+import PromptSidebar from "@/components/PromptSidebar";
+import ProjectFileTree from "@/components/ProjectFileTree";
+import ProjectSandpack from "@/components/ProjectSandpack";
+import type { GeneratedProject } from "@/lib/project-generator";
+import { generateProjectFromPrompt } from "@/lib/project-generator";
+
+export type SiteAppMode = "website" | "application";
+
+interface SiteAppGeneratorProps {
+  mode: SiteAppMode;
+}
+
+const DEFAULT_PROMPTS: Record<SiteAppMode, string> = {
+  website: [
+    "Crée une landing page moderne",
+    "Nom: Mon Super Site",
+    "Ajoute un bouton vert",
+  ].join("\n"),
+  application: [
+    "Prototype d'application dashboard",
+    "Nom: Mon App Produit",
+    "Inclut suivi des statistiques",
+  ].join("\n"),
+};
+
+const HINTS: Record<SiteAppMode, string[]> = {
+  website: [
+    "Landing page SaaS",
+    "Section témoignages",
+    "Nom: Startup Nova",
+    "Bouton vert",
+  ],
+  application: [
+    "Dashboard analytique",
+    "Vue Kanban",
+    "Nom: Flow Manager",
+    "Mode sombre",
+  ],
+};
+
+const LABELS: Record<SiteAppMode, { title: string; description: string; generate: string }> = {
+  website: {
+    title: "Générateur de site web",
+    description:
+      "Décris la landing page ou le site marketing que tu veux obtenir. Utilise <code>Nom: ...</code> pour définir le nom du projet.",
+    generate: "Générer le site",
+  },
+  application: {
+    title: "Générateur d'application",
+    description:
+      "Décris l'application React que tu souhaites prototyper. Mentionne <code>Nom: ...</code> pour personnaliser le dossier.",
+    generate: "Générer l'application",
+  },
+};
+
+const SiteAppGenerator = ({ mode }: SiteAppGeneratorProps) => {
+  const defaultPrompt = useMemo(() => DEFAULT_PROMPTS[mode], [mode]);
+  const [prompt, setPrompt] = useState(defaultPrompt);
+  const [project, setProject] = useState<GeneratedProject | null>(null);
+  const [activeFile, setActiveFile] = useState<string | undefined>();
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
+
+  useEffect(() => {
+    setPrompt(defaultPrompt);
+    setProject(null);
+    setActiveFile(undefined);
+  }, [defaultPrompt]);
+
+  const projectFiles = useMemo(() => project?.files ?? [], [project]);
+
+  const handleGenerate = useCallback(() => {
+    if (!prompt.trim()) {
+      toast.error("Ajoute quelques instructions avant de lancer la génération.");
+      return;
+    }
+
+    try {
+      setIsGenerating(true);
+      const generated = generateProjectFromPrompt(prompt, mode);
+      setProject(generated);
+
+      const preferredFile = generated.files.find(
+        (file) => file.path === "src/App.tsx" || file.path === "src/main.tsx",
+      );
+      setActiveFile(preferredFile?.path ?? generated.files[0]?.path);
+
+      toast.success(
+        mode === "website"
+          ? "Projet de site React + Vite généré !"
+          : "Prototype d'application React généré !",
+      );
+    } catch (error) {
+      console.error("Erreur pendant la génération", error);
+      toast.error("Impossible de générer le projet. Réessaie avec un prompt différent.");
+    } finally {
+      setIsGenerating(false);
+    }
+  }, [mode, prompt]);
+
+  const handleExport = useCallback(async () => {
+    if (!project) return;
+
+    try {
+      setIsExporting(true);
+      const zip = new JSZip();
+
+      project.files.forEach((file) => {
+        zip.file(file.path, file.content);
+      });
+
+      if (project.instructions) {
+        zip.file("README.md", project.instructions);
+      }
+
+      const blob = await zip.generateAsync({ type: "blob" });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      const slug = project.projectName.replace(/\s+/g, "-").toLowerCase();
+      link.href = url;
+      link.download = `${slug || "react-project"}.zip`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+
+      toast.success("Archive du projet prête à être téléchargée !");
+    } catch (error) {
+      console.error("Erreur lors de l'export", error);
+      toast.error("Impossible de créer l'archive du projet.");
+    } finally {
+      setIsExporting(false);
+    }
+  }, [project]);
+
+  return (
+    <div className="flex h-full w-full bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950">
+      <div className="grid h-full w-full grid-cols-[minmax(280px,340px)_minmax(240px,280px)_1fr] bg-background/60">
+        <PromptSidebar
+          prompt={prompt}
+          onPromptChange={setPrompt}
+          onGenerate={handleGenerate}
+          onExport={handleExport}
+          isGenerating={isGenerating}
+          isExporting={isExporting}
+          canExport={Boolean(projectFiles.length) && !isExporting}
+          projectName={project?.projectName}
+          instructions={project?.instructions}
+          title={LABELS[mode].title}
+          description={LABELS[mode].description}
+          promptLabel="Brief"
+          promptPlaceholder={defaultPrompt}
+          hints={HINTS[mode]}
+          generateLabel={LABELS[mode].generate}
+          exportLabel="Télécharger le projet"
+        />
+
+        <ProjectFileTree files={projectFiles} activeFile={activeFile} onSelect={setActiveFile} />
+
+        <ProjectSandpack files={projectFiles} activeFile={activeFile} />
+      </div>
+    </div>
+  );
+};
+
+export default SiteAppGenerator;

--- a/src/lib/content-generators.ts
+++ b/src/lib/content-generators.ts
@@ -1,0 +1,224 @@
+import type { GeneratedResult } from "@/types/result";
+
+export type CreativeTool = "image" | "music" | "agent" | "game";
+
+interface GenerationOptions {
+  prompt: string;
+  version: number;
+  modification?: string;
+  previous?: GeneratedResult | null;
+}
+
+const TOOL_LABELS: Record<CreativeTool, string> = {
+  image: "Générateur d'image",
+  music: "Générateur de musique",
+  agent: "Générateur d'agents",
+  game: "Générateur de jeux vidéo",
+};
+
+const simpleHash = (value: string) => {
+  let hash = 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash << 5) - hash + value.charCodeAt(index);
+    hash |= 0;
+  }
+  return Math.abs(hash);
+};
+
+const pick = <T,>(items: T[], hash: number, offset: number) =>
+  items[(hash + offset) % items.length];
+
+const generateImageResult = (options: GenerationOptions): GeneratedResult => {
+  const { prompt, version, modification } = options;
+  const hash = simpleHash(`${prompt}|${modification ?? ""}`);
+  const palette = ["saphir", "ambre", "magenta", "menthe", "ardoise"];
+  const styles = ["cinématique", "illustration vectorielle", "peinture digitale", "3D réaliste", "aquarelle"];
+  const mood = ["mystérieuse", "lumineuse", "futuriste", "organique", "minimaliste"];
+
+  const preview = `https://picsum.photos/seed/${encodeURIComponent(`${hash}-${version}`)}/1200/800`;
+  const caption = `Style ${pick(styles, hash, 1)} · palette ${pick(palette, hash, 3)} · ambiance ${pick(mood, hash, 5)}`;
+
+  return {
+    type: "image",
+    category: TOOL_LABELS.image,
+    prompt,
+    version,
+    modification,
+    preview,
+    content: caption,
+  };
+};
+
+const generateMusicResult = (options: GenerationOptions): GeneratedResult => {
+  const { prompt, version, modification } = options;
+  const hash = simpleHash(`${prompt}|${modification ?? ""}`);
+
+  const genres = ["Synthwave", "Lo-fi chill", "Ambient organique", "Electro-pop", "Cinematic"];
+  const moods = ["énergique", "reposante", "immersive", "nostalgique", "motivée"];
+  const tempos = ["82 BPM", "96 BPM", "108 BPM", "122 BPM", "132 BPM"];
+  const instruments = [
+    "Synthés analogiques, basse ronde, batterie électronique",
+    "Piano feutré, textures granuleuses, percussions douces",
+    "Cordes éthérées, nappes atmosphériques, sub bass",
+    "Guitares modulées, arps, beat hybride",
+    "Pads cinématiques, percussions organiques, chœurs traités",
+  ];
+  const structures = [
+    "Intro · Couplets évolutifs · Pont texturé · Finale expansif",
+    "Intro ambient · Groove principal · Breakdown · Reprise", 
+    "Intro granulaire · Build progressif · Drop contrasté · Outro immersif",
+    "Ambient opening · Hook principal · Variation rythmique · Outro en fondu",
+    "Intro percussive · Section A/B · Climax harmonique · Outro suspendu",
+  ];
+
+  const genre = pick(genres, hash, 0);
+  const mood = pick(moods, hash, 2);
+  const tempo = pick(tempos, hash, 4);
+  const instrumentation = pick(instruments, hash, 6);
+  const structure = pick(structures, hash, 8);
+
+  const content = [
+    `Titre proposé : « ${genre} ${mood} »`,
+    `Tempo : ${tempo}`,
+    `Ambiance : ${mood}`,
+    `Instrumentation clé : ${instrumentation}`,
+    `Structure recommandée : ${structure}`,
+    "Export suggéré : 48 kHz · 24 bits",
+  ].join("\n");
+
+  return {
+    type: "description",
+    category: TOOL_LABELS.music,
+    prompt,
+    version,
+    modification,
+    content,
+  };
+};
+
+const generateAgentResult = (options: GenerationOptions): GeneratedResult => {
+  const { prompt, version, modification, previous } = options;
+  const hash = simpleHash(`${prompt}|${modification ?? ""}`);
+
+  const personas = [
+    "Analyste stratégique",
+    "Assistant produit",
+    "Coach de productivité",
+    "Planificateur marketing",
+    "Architecte d'expériences",
+  ];
+  const tools = [
+    "Notion",
+    "Slack",
+    "Figma",
+    "Airtable",
+    "Linear",
+  ];
+
+  const steps = [
+    "Analyse la demande et extrait les objectifs clés.",
+    "Génère un plan d'action structuré étape par étape.",
+    "Identifie les dépendances et ressources nécessaires.",
+    "Synthétise les livrables attendus et les jalons.",
+  ];
+
+  const persona = pick(personas, hash, 1);
+  const stack = [pick(tools, hash, 2), pick(tools, hash, 4), pick(tools, hash, 6)]
+    .filter((value, index, array) => array.indexOf(value) === index)
+    .join(", ");
+
+  const refinement = modification
+    ? `\n\nAdaptation demandée : ${modification}.`
+    : "";
+  const followUp = previous
+    ? "\n\nL'agent conserve la mémoire de la version précédente pour ajuster ses tâches."
+    : "";
+
+  const content = [
+    `Agent proposé : ${persona}`,
+    `Outils suggérés : ${stack}`,
+    "Routine de travail :",
+    ...steps.map((step, index) => `${index + 1}. ${step}`),
+  ].join("\n");
+
+  return {
+    type: "description",
+    category: TOOL_LABELS.agent,
+    prompt,
+    version,
+    modification,
+    content: content + refinement + followUp,
+  };
+};
+
+const generateGameResult = (options: GenerationOptions): GeneratedResult => {
+  const { prompt, version, modification } = options;
+  const hash = simpleHash(`${prompt}|${modification ?? ""}`);
+
+  const genres = [
+    "Rogue-lite narratif",
+    "Puzzle aventure",
+    "Gestion stratégique",
+    "Exploration coopérative",
+    "Action tactique",
+  ];
+  const settings = [
+    "mégalopole néon",
+    "archipel suspendu",
+    "station orbitale",
+    "forêt numérique",
+    "cité souterraine",
+  ];
+  const mechanics = [
+    "boucle temporelle adaptative",
+    "craft collaboratif",
+    "systèmes procéduraux influencés par les choix",
+    "narration ramifiée",
+    "gestion d'équipes autonomes",
+  ];
+
+  const genre = pick(genres, hash, 0);
+  const setting = pick(settings, hash, 3);
+  const mechanic = pick(mechanics, hash, 5);
+
+  const content = [
+    `Concept : ${genre} dans une ${setting}.`,
+    `Mécanique signature : ${mechanic}.`,
+    "Boucle de jeu :",
+    "1. Préparation des missions et sélection des compétences.",
+    "2. Exploration générative avec événements dynamiques.",
+    "3. Phase de résolution influencée par les choix narratifs.",
+    "4. Déblocage d'améliorations persistantes.",
+    "\nPilier artistique : mélange de low-poly stylisé et d'effets lumineux volumétriques.",
+    "Progression : met en avant la rejouabilité par cartes modulaires et scénarios évolutifs.",
+  ].join("\n");
+
+  return {
+    type: "description",
+    category: TOOL_LABELS.game,
+    prompt,
+    version,
+    modification,
+    content,
+  };
+};
+
+export const generateCreativeResult = (
+  tool: CreativeTool,
+  options: GenerationOptions,
+): GeneratedResult => {
+  switch (tool) {
+    case "image":
+      return generateImageResult(options);
+    case "music":
+      return generateMusicResult(options);
+    case "agent":
+      return generateAgentResult(options);
+    case "game":
+      return generateGameResult(options);
+    default:
+      return generateImageResult(options);
+  }
+};
+
+export const getCreativeToolLabel = (tool: CreativeTool) => TOOL_LABELS[tool];

--- a/src/lib/project-generator.ts
+++ b/src/lib/project-generator.ts
@@ -12,6 +12,7 @@ export interface GeneratedProject {
 }
 
 type FileMap = Record<string, FileDescriptor>;
+type ProjectKind = "website" | "application";
 
 const normalizePath = (path: string) => (path.startsWith("/") ? path : `/${path}`);
 
@@ -163,6 +164,185 @@ export default function App(){
   }
 });
 
+const baseReactApp = (projectName: string): FileMap => ({
+  "/index.html": {
+    code: `<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>${projectName}</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>`
+  },
+  "/src/main.tsx": {
+    code: `import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+)`
+  },
+  "/src/App.tsx": {
+    code: `import React, { useState } from 'react'
+import './index.css'
+
+const navigation = [
+  { id: 'overview', label: "Vue d'ensemble" },
+  { id: 'utilisateurs', label: 'Utilisateurs' },
+  { id: 'produit', label: 'Produit' },
+  { id: 'reporting', label: 'Reporting' }
+]
+
+const analytics = [
+  { label: 'Utilisateurs actifs', value: '1 284', delta: '+18% cette semaine' },
+  { label: 'Taux de conversion', value: '4,2%', delta: '+0,4 points' },
+  { label: 'Sessions', value: '32 458', delta: '+9% vs 7 derniers jours' },
+  { label: 'Satisfaction', value: '92%', delta: 'Score NPS' }
+]
+
+export default function App(){
+  const [active, setActive] = useState('overview')
+
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <header className="border-b border-slate-800/80 bg-slate-900/60 px-6 py-4 backdrop-blur">
+        <h1 className="text-2xl font-semibold tracking-tight">${projectName}</h1>
+        <p className="text-sm text-slate-400">Application générée automatiquement</p>
+      </header>
+      <main className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-6 py-8">
+        <nav className="flex flex-wrap items-center gap-2">
+          {navigation.map((item) => (
+            <button
+              key={item.id}
+              onClick={() => setActive(item.id)}
+              className={
+                active === item.id
+                  ? 'rounded-lg border border-indigo-500 bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-lg shadow-indigo-600/30 transition'
+                  : 'rounded-lg border border-slate-800/80 bg-slate-900/60 px-4 py-2 text-sm font-medium text-slate-200 transition hover:border-indigo-500/60'
+              }
+            >
+              {item.label}
+            </button>
+          ))}
+        </nav>
+
+        <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+          {analytics.map((card) => (
+            <div key={card.label} className="rounded-xl border border-slate-800/80 bg-slate-900/60 p-5">
+              <p className="text-sm text-slate-400">{card.label}</p>
+              <p className="mt-2 text-2xl font-semibold text-white">{card.value}</p>
+              <p className="mt-3 text-xs text-emerald-400">{card.delta}</p>
+            </div>
+          ))}
+        </section>
+
+        <section className="grid gap-6 lg:grid-cols-[2fr_1fr]">
+          <div className="rounded-xl border border-slate-800/80 bg-slate-900/60 p-6">
+            <h2 className="text-lg font-semibold text-white">Activité récente</h2>
+            <p className="mt-2 text-sm text-slate-400">
+              Ajoute tes propres composants dans <code className="rounded bg-slate-800 px-1 py-0.5 text-xs">src/</code> pour transformer cette base en application complète.
+            </p>
+            <ul className="mt-4 space-y-3 text-sm text-slate-300">
+              <li className="flex items-center justify-between rounded-lg border border-slate-800/80 bg-slate-900/80 px-4 py-3">
+                <span>Nouvel utilisateur inscrit</span>
+                <span className="text-xs text-slate-500">Il y a 2 min</span>
+              </li>
+              <li className="flex items-center justify-between rounded-lg border border-slate-800/80 bg-slate-900/80 px-4 py-3">
+                <span>Plan Professionnel activé</span>
+                <span className="text-xs text-slate-500">Il y a 12 min</span>
+              </li>
+              <li className="flex items-center justify-between rounded-lg border border-slate-800/80 bg-slate-900/80 px-4 py-3">
+                <span>Nouvelle intégration connectée</span>
+                <span className="text-xs text-slate-500">Il y a 32 min</span>
+              </li>
+            </ul>
+          </div>
+
+          <aside className="rounded-xl border border-slate-800/80 bg-slate-900/60 p-6">
+            <h2 className="text-lg font-semibold text-white">Tâches prioritaires</h2>
+            <div className="mt-3 space-y-3 text-sm text-slate-200">
+              <label className="flex items-start gap-3">
+                <input type="checkbox" className="mt-1 h-4 w-4 rounded border-slate-700 bg-slate-900 text-indigo-500" />
+                <span>Lancer la campagne d'onboarding</span>
+              </label>
+              <label className="flex items-start gap-3">
+                <input type="checkbox" className="mt-1 h-4 w-4 rounded border-slate-700 bg-slate-900 text-indigo-500" />
+                <span>Prioriser les demandes clients</span>
+              </label>
+              <label className="flex items-start gap-3">
+                <input type="checkbox" className="mt-1 h-4 w-4 rounded border-slate-700 bg-slate-900 text-indigo-500" />
+                <span>Analyser les données d'usage</span>
+              </label>
+            </div>
+            <button className="mt-6 inline-flex items-center justify-center rounded-lg bg-indigo-600 px-4 py-2 text-sm font-medium text-white transition hover:bg-indigo-500">
+              Voir toutes les tâches
+            </button>
+          </aside>
+        </section>
+      </main>
+    </div>
+  )
+}`
+  },
+  "/src/index.css": {
+    code: `*{box-sizing:border-box} body{margin:0;font-family:ui-sans-serif,system-ui;background:#020617;color:#e2e8f0}`
+  },
+  "/package.json": {
+    code: `{
+  "name": "${projectName.toLowerCase().replace(/\s+/g,'-')}",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5",
+    "@types/react": "^18.2.47",
+    "@types/react-dom": "^18.2.17",
+    "vite": "^5.0.12"
+  }
+}`
+  },
+  "/tsconfig.json": {
+    code: `{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  }
+}`
+  },
+  "/vite.config.ts": {
+    code: `import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+})`
+  }
+});
+
 const applyGreenButton = (files: FileMap) => {
   const app = files["/src/App.tsx"];
 
@@ -193,13 +373,16 @@ const extractProjectName = (prompt: string) => {
   return match ? sanitizeProjectName(match[1]) : undefined;
 };
 
-export const generateProjectFromPrompt = (prompt: string): GeneratedProject => {
+export const generateProjectFromPrompt = (
+  prompt: string,
+  kind: ProjectKind = "website",
+): GeneratedProject => {
   const projectName = extractProjectName(prompt) ?? "Projet Généré";
   const lowered = prompt.toLowerCase();
 
-  let files = baseReactVite(projectName);
+  let files = kind === "application" ? baseReactApp(projectName) : baseReactVite(projectName);
 
-  if (lowered.includes("landing") || lowered.includes("accueil")) {
+  if (kind === "website" && (lowered.includes("landing") || lowered.includes("accueil"))) {
     files = { ...files, ...landingPageAddon() };
   }
 
@@ -210,9 +393,14 @@ export const generateProjectFromPrompt = (prompt: string): GeneratedProject => {
   const instructions = [
     `Projet React + Vite généré pour : ${projectName}.`,
     "Inclut les fichiers essentiels (index.html, src/main.tsx, src/App.tsx, etc.).",
-    lowered.includes("landing") || lowered.includes("accueil")
-      ? "Composant Hero ajouté pour une landing page."
-      : "Structure de base prête à être personnalisée.",
+    kind === "website"
+      ? lowered.includes("landing") || lowered.includes("accueil")
+        ? "Composant Hero ajouté pour une landing page."
+        : "Structure de base prête à être personnalisée."
+      : "Tableau de bord React avec navigation simulée et widgets prêts à personnaliser.",
+    kind === "application"
+      ? "Utilise React.useState pour gérer l'onglet actif et propose des sections Activité/Tâches."
+      : "Section principale prête à être enrichie avec vos composants.",
     lowered.includes("bouton vert")
       ? "Style du bouton principal ajusté en vert comme demandé."
       : "Couleurs par défaut conservées.",

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,110 +1,177 @@
 import { useCallback, useMemo, useState } from "react";
-import JSZip from "jszip";
-import { toast } from "sonner";
-import PromptSidebar from "@/components/PromptSidebar";
-import ProjectFileTree from "@/components/ProjectFileTree";
-import ProjectSandpack from "@/components/ProjectSandpack";
-import type { GeneratedProject } from "@/lib/project-generator";
-import { generateProjectFromPrompt } from "@/lib/project-generator";
 
-const defaultPrompt = [
-  "Crée une landing page moderne",
-  "Nom: Mon Super Site",
-  "Ajoute un bouton vert",
-].join("\n");
+import { Dialog, DialogContent } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import CategoryCard from "@/components/CategoryCard";
+import SiteAppGenerator, { type SiteAppMode } from "@/components/SiteAppGenerator";
+import CreativeGenerator from "@/components/CreativeGenerator";
+import type { CreativeTool } from "@/lib/content-generators";
+
+import heroBanner from "@/assets/hero-banner.jpg";
+import webIcon from "@/assets/web-icon.png";
+import appIcon from "@/assets/app-icon.png";
+import imageIcon from "@/assets/image-icon.png";
+import musicIcon from "@/assets/music-icon.png";
+import agentIcon from "@/assets/agent-icon.png";
+import gameIcon from "@/assets/game-icon.png";
+
+type ToolType = SiteAppMode | CreativeTool;
+
+type ToolDefinition = {
+  title: string;
+  description: string;
+  icon: string;
+  kind: "builder" | "creative";
+  dialogDescription: string;
+};
+
+const TOOL_ORDER: ToolType[] = ["website", "application", "image", "music", "agent", "game"];
+
+const TOOL_DETAILS: Record<ToolType, ToolDefinition> = {
+  website: {
+    title: "Sites web",
+    description: "Landing pages modernes, sections prêtes à personnaliser et styles adaptables.",
+    icon: webIcon,
+    kind: "builder",
+    dialogDescription:
+      "Décris ton site web pour générer un projet React + Vite complet avec structure de pages et fichiers essentiels.",
+  },
+  application: {
+    title: "Applications",
+    description: "Dashboards réactifs avec navigation, widgets et listes de tâches interactives.",
+    icon: appIcon,
+    kind: "builder",
+    dialogDescription:
+      "Génère un prototype d'application React avec navigation, statistiques et sections prêtes à enrichir.",
+  },
+  image: {
+    title: "Images",
+    description: "Visuels inspirants générés depuis vos idées et styles préférés.",
+    icon: imageIcon,
+    kind: "creative",
+    dialogDescription:
+      "Décris la scène ou l'ambiance recherchée pour obtenir un aperçu d'image illustratif.",
+  },
+  music: {
+    title: "Musique",
+    description: "Concepts musicaux complets avec tempo, instrumentation et structure.",
+    icon: musicIcon,
+    kind: "creative",
+    dialogDescription:
+      "Explique l'ambiance musicale souhaitée pour obtenir une fiche de composition détaillée.",
+  },
+  agent: {
+    title: "Agents",
+    description: "Conçois des assistants intelligents avec objectifs, routine et outils.",
+    icon: agentIcon,
+    kind: "creative",
+    dialogDescription:
+      "Précise le rôle de ton agent afin de générer un plan d'action et les outils recommandés.",
+  },
+  game: {
+    title: "Jeux vidéo",
+    description: "Pitchs de jeux immersifs avec mécaniques, boucle de gameplay et univers.",
+    icon: gameIcon,
+    kind: "creative",
+    dialogDescription:
+      "Décris l'expérience de jeu pour obtenir un concept détaillé avec boucle de gameplay et ambiance visuelle.",
+  },
+};
 
 const Index = () => {
-  const [prompt, setPrompt] = useState(defaultPrompt);
-  const [project, setProject] = useState<GeneratedProject | null>(null);
-  const [activeFile, setActiveFile] = useState<string | undefined>();
-  const [isGenerating, setIsGenerating] = useState(false);
-  const [isExporting, setIsExporting] = useState(false);
+  const [activeTool, setActiveTool] = useState<ToolType | null>(null);
 
-  const handleGenerate = useCallback(() => {
-    if (!prompt.trim()) {
-      toast.error("Veuillez décrire votre projet avant de lancer la génération.");
-      return;
+  const tools = useMemo(
+    () => TOOL_ORDER.map((key) => ({ key, ...TOOL_DETAILS[key] })),
+    [],
+  );
+
+  const handleOpen = useCallback((tool: ToolType) => {
+    setActiveTool(tool);
+  }, []);
+
+  const handleDialogChange = useCallback((open: boolean) => {
+    if (!open) {
+      setActiveTool(null);
     }
+  }, []);
 
-    try {
-      setIsGenerating(true);
-      const generated = generateProjectFromPrompt(prompt);
-      setProject(generated);
-
-      const preferredFile = generated.files.find((file) => file.path === "src/App.tsx" || file.path === "src/main.tsx");
-      setActiveFile(preferredFile?.path ?? generated.files[0]?.path);
-
-      toast.success("Projet React + Vite généré !");
-    } catch (error) {
-      console.error("Erreur pendant la génération", error);
-      toast.error("Impossible de générer le projet. Réessayez avec un prompt différent.");
-    } finally {
-      setIsGenerating(false);
-    }
-  }, [prompt]);
-
-  const handleExport = useCallback(async () => {
-    if (!project) return;
-
-    try {
-      setIsExporting(true);
-      const zip = new JSZip();
-
-      project.files.forEach((file) => {
-        zip.file(file.path, file.content);
-      });
-
-      if (project.instructions) {
-        zip.file("README.md", project.instructions);
-      }
-
-      const blob = await zip.generateAsync({ type: "blob" });
-      const url = URL.createObjectURL(blob);
-      const link = document.createElement("a");
-      const slug = project.projectName.replace(/\s+/g, "-").toLowerCase();
-      link.href = url;
-      link.download = `${slug || "react-project"}.zip`;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      URL.revokeObjectURL(url);
-
-      toast.success("Archive du projet prête à être téléchargée !");
-    } catch (error) {
-      console.error("Erreur lors de l'export", error);
-      toast.error("Impossible de créer l'archive du projet.");
-    } finally {
-      setIsExporting(false);
-    }
-  }, [project]);
-
-  const projectFiles = useMemo(() => project?.files ?? [], [project]);
+  const activeDetail = activeTool ? TOOL_DETAILS[activeTool] : null;
+  const isBuilder = activeDetail?.kind === "builder";
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 text-foreground">
-      <div className="flex h-screen w-full overflow-hidden">
-        <div className="grid h-full w-full grid-cols-[minmax(280px,340px)_minmax(240px,280px)_1fr] bg-background/80">
-          <PromptSidebar
-            prompt={prompt}
-            onPromptChange={setPrompt}
-            onGenerate={handleGenerate}
-            onExport={handleExport}
-            isGenerating={isGenerating}
-            isExporting={isExporting}
-            canExport={Boolean(projectFiles.length) && !isExporting}
-            projectName={project?.projectName}
-            instructions={project?.instructions}
-          />
-
-          <ProjectFileTree
-            files={projectFiles}
-            activeFile={activeFile}
-            onSelect={setActiveFile}
-          />
-
-          <ProjectSandpack files={projectFiles} activeFile={activeFile} />
+    <div className="min-h-screen bg-slate-950 text-foreground">
+      <section className="relative overflow-hidden">
+        <img
+          src={heroBanner}
+          alt="Fond créatif"
+          className="absolute inset-0 h-full w-full object-cover opacity-20"
+        />
+        <div className="absolute inset-0 bg-gradient-to-br from-slate-950 via-slate-950/90 to-violet-900/40" />
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(129,140,248,0.35),_transparent_60%)]" />
+        <div className="relative z-10 container mx-auto px-6 py-24 sm:px-10 lg:px-16">
+          <div className="max-w-3xl space-y-6">
+            <span className="inline-flex items-center rounded-full border border-white/10 bg-white/5 px-4 py-1 text-xs font-semibold uppercase tracking-[0.2em] text-slate-200/80 backdrop-blur">
+              Studio génératif
+            </span>
+            <h1 className="text-4xl font-semibold leading-tight text-white sm:text-5xl lg:text-6xl">
+              Créez sites, applications, images et expériences immersives en quelques secondes.
+            </h1>
+            <p className="text-lg text-slate-200/80">
+              Choisissez un générateur, décrivez votre idée et obtenez instantanément du code, des visuels ou des concepts prêts à
+              explorer.
+            </p>
+            <div className="flex flex-wrap gap-3">
+              <Button size="lg" onClick={() => handleOpen("website")}>Commencer un site</Button>
+              <Button
+                size="lg"
+                variant="outline"
+                onClick={() => document.getElementById("tools-grid")?.scrollIntoView({ behavior: "smooth" })}
+                className="border-white/30 text-slate-100 hover:border-white/60"
+              >
+                Voir tous les générateurs
+              </Button>
+            </div>
+          </div>
         </div>
-      </div>
+      </section>
+
+      <section id="tools-grid" className="container mx-auto px-6 py-16 sm:px-10 lg:px-16">
+        <div className="max-w-2xl">
+          <h2 className="text-2xl font-semibold text-white sm:text-3xl">Les 6 générateurs créatifs</h2>
+          <p className="mt-2 text-slate-300/80">
+            Sélectionne un outil pour ouvrir l'environnement de création dédié à ton besoin.
+          </p>
+        </div>
+
+        <div className="mt-10 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {tools.map((tool) => (
+            <CategoryCard
+              key={tool.key}
+              title={tool.title}
+              description={tool.description}
+              icon={tool.icon}
+              onClick={() => handleOpen(tool.key as ToolType)}
+            />
+          ))}
+        </div>
+      </section>
+
+      <Dialog open={Boolean(activeTool)} onOpenChange={handleDialogChange}>
+        <DialogContent className="max-w-[1200px] w-full max-h-[90vh] overflow-hidden border border-white/10 bg-slate-950/95 p-0 backdrop-blur-xl">
+          {activeTool && activeDetail && (
+            isBuilder ? (
+              <SiteAppGenerator key={activeTool} mode={activeTool as SiteAppMode} />
+            ) : (
+              <CreativeGenerator
+                key={activeTool}
+                tool={activeTool as CreativeTool}
+                description={activeDetail.dialogDescription}
+              />
+            )
+          )}
+        </DialogContent>
+      </Dialog>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- redesign the home page with a hero section and tool grid that opens the generator in a dialog
- add dedicated site/app project workspace plus creative generators for images, music, agents, and games
- extend the project generator templates and prompt sidebar configuration for tool-specific behavior

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcd075a7608323810b6fef7f21e254