### PR TITLE
feat: orchestrate plan-first generation flows

### DIFF
--- a/src/components/CreativeGenerator.tsx
+++ b/src/components/CreativeGenerator.tsx
@@ -1,27 +1,108 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 
 import PromptInput from "@/components/PromptInput";
 import ResultDisplay from "@/components/ResultDisplay";
+import GenerationPlanView from "@/components/GenerationPlanView";
+import GenerationProgress from "@/components/GenerationProgress";
 import type { GeneratedResult } from "@/types/result";
+import type { GenerationPlan, PlanExecutionStep, PlanStepStatus } from "@/types/plan";
 import {
+  createCreativePlan,
   generateCreativeResult,
   getCreativeToolLabel,
   type CreativeTool,
 } from "@/lib/content-generators";
+
+type Phase = "idle" | "planning" | "generating" | "complete";
 
 interface CreativeGeneratorProps {
   tool: CreativeTool;
   description: string;
 }
 
+const toExecutionSteps = (plan: GenerationPlan): PlanExecutionStep[] => {
+  const steps = plan.sections.flatMap((section) =>
+    section.steps.map((step) => ({
+      ...step,
+      section: section.title,
+      status: "pending" as PlanStepStatus,
+    })),
+  );
+
+  if (!steps.length) {
+    return [
+      {
+        id: "analyse",
+        title: "Analyser le brief",
+        description: "Décomposer la demande et préparer la réponse.",
+        deliverable: "Synthèse du brief",
+        section: plan.title,
+        status: "pending",
+      },
+      {
+        id: "production",
+        title: "Rédiger la proposition",
+        description: "Assembler le contenu génératif étape par étape.",
+        deliverable: "Proposition complète",
+        section: plan.title,
+        status: "pending",
+      },
+    ];
+  }
+
+  return steps;
+};
+
 const CreativeGenerator = ({ tool, description }: CreativeGeneratorProps) => {
   const [history, setHistory] = useState<GeneratedResult[]>([]);
   const [result, setResult] = useState<GeneratedResult | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [lastPrompt, setLastPrompt] = useState("");
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [plan, setPlan] = useState<GenerationPlan | null>(null);
+  const [executionSteps, setExecutionSteps] = useState<PlanExecutionStep[]>([]);
+  const [statusHistory, setStatusHistory] = useState<string[]>([]);
+  const [statusMessage, setStatusMessage] = useState<string>("");
+  const [pendingPrompt, setPendingPrompt] = useState<string>("");
+  const [pendingModification, setPendingModification] = useState<string | undefined>();
+  const timersRef = useRef<number[]>([]);
+
+  const clearTimers = useCallback(() => {
+    timersRef.current.forEach((identifier) => window.clearTimeout(identifier));
+    timersRef.current = [];
+  }, []);
+
+  const resetProgress = useCallback(() => {
+    clearTimers();
+    setExecutionSteps([]);
+    setStatusHistory([]);
+    setStatusMessage("");
+  }, [clearTimers]);
 
   const label = useMemo(() => getCreativeToolLabel(tool), [tool]);
+
+  const handlePlanRequest = useCallback(
+    (basePrompt: string, modification?: string) => {
+      try {
+        setIsLoading(true);
+        resetProgress();
+        const generatedPlan = createCreativePlan(tool, basePrompt, modification);
+        setPlan(generatedPlan);
+        setPhase("planning");
+        setStatusHistory(["Plan proposé à partir du brief"]);
+        setStatusMessage("Valide ou ajuste le plan avant la génération.");
+        toast.success("Plan d'action généré !");
+      } catch (error) {
+        console.error("Erreur lors de la génération du plan", error);
+        toast.error("Impossible de générer un plan pour cette demande.");
+        setPhase("idle");
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [resetProgress, tool],
+  );
 
   const handleSubmit = useCallback(
     (prompt: string) => {
@@ -30,57 +111,108 @@ const CreativeGenerator = ({ tool, description }: CreativeGeneratorProps) => {
         return;
       }
 
-      try {
-        setIsLoading(true);
-        const version = history.length + 1;
-        const generated = generateCreativeResult(tool, {
-          prompt,
-          version,
-          previous: result,
-        });
-        setHistory((previous) => [...previous, generated]);
-        setResult(generated);
-        setLastPrompt(prompt);
-        toast.success("Création générée !");
-      } catch (error) {
-        console.error("Erreur pendant la génération", error);
-        toast.error("Impossible de créer ce contenu pour le moment.");
-      } finally {
-        setIsLoading(false);
-      }
+      setPendingPrompt(prompt);
+      setPendingModification(undefined);
+      handlePlanRequest(prompt);
     },
-    [history.length, result, tool],
+    [handlePlanRequest],
   );
 
   const handleRefineSubmit = useCallback(
     (modification: string) => {
-      if (!result) return;
+      if (!result) {
+        toast.error("Génère d'abord un contenu avant de demander une modification.");
+        return;
+      }
+
       if (!modification.trim()) {
         toast.error("Décris l'ajustement souhaité avant de lancer une révision.");
         return;
       }
 
-      try {
-        setIsLoading(true);
-        const version = history.length + 1;
-        const generated = generateCreativeResult(tool, {
-          prompt: lastPrompt || result.prompt,
-          version,
-          modification,
-          previous: result,
-        });
-        setHistory((previous) => [...previous, generated]);
-        setResult(generated);
-        toast.success("Révision générée !");
-      } catch (error) {
-        console.error("Erreur pendant la révision", error);
-        toast.error("Impossible d'appliquer cette modification.");
-      } finally {
-        setIsLoading(false);
-      }
+      const basePrompt = lastPrompt || result.prompt;
+      setPendingPrompt(basePrompt);
+      setPendingModification(modification);
+      handlePlanRequest(basePrompt, modification);
     },
-    [history.length, lastPrompt, result, tool],
+    [handlePlanRequest, lastPrompt, result],
   );
+
+  const handleEditPlan = useCallback(() => {
+    resetProgress();
+    setPlan(null);
+    setPhase("idle");
+    setPendingModification(undefined);
+  }, [resetProgress]);
+
+  const handleConfirmPlan = useCallback(() => {
+    if (!plan) return;
+
+    setIsLoading(true);
+    setPhase("generating");
+
+    const steps = toExecutionSteps(plan);
+    setExecutionSteps(steps);
+    setStatusHistory((previous) => [...previous, "Plan validé · génération en cours"]);
+    setStatusMessage("Initialisation");
+
+    clearTimers();
+
+    steps.forEach((step, index) => {
+      const startDelay = index * 900;
+      const endDelay = startDelay + 750;
+
+      const startTimer = window.setTimeout(() => {
+        setExecutionSteps((previous) =>
+          previous.map((entry, entryIndex) => {
+            if (entryIndex < index) {
+              return { ...entry, status: "done" };
+            }
+            if (entryIndex === index) {
+              return { ...entry, status: "active" };
+            }
+            return entry;
+          }),
+        );
+        setStatusMessage(`${step.section} · ${step.title}`);
+        setStatusHistory((previous) => [...previous, `▶️ ${step.title}`]);
+      }, startDelay);
+
+      const endTimer = window.setTimeout(() => {
+        setExecutionSteps((previous) =>
+          previous.map((entry, entryIndex) =>
+            entryIndex === index ? { ...entry, status: "done" } : entry,
+          ),
+        );
+        setStatusHistory((previous) => [...previous, `✅ ${step.title}`]);
+
+        if (index === steps.length - 1) {
+          const version = history.length + 1;
+          const basePrompt = pendingPrompt || plan.summary;
+          const generated = generateCreativeResult(tool, {
+            prompt: basePrompt,
+            version,
+            modification: pendingModification,
+            previous: result,
+          });
+
+          setHistory((previous) => [...previous, generated]);
+          setResult(generated);
+          setLastPrompt(basePrompt);
+          setPhase("complete");
+          setPlan(plan);
+          setIsLoading(false);
+          setStatusMessage("Génération terminée");
+          toast.success(pendingModification ? "Révision générée !" : "Création générée !");
+          setPendingPrompt("");
+          setPendingModification(undefined);
+          clearTimers();
+        }
+      }, endDelay);
+
+      timersRef.current.push(startTimer, endTimer);
+    });
+  }, [clearTimers, history.length, pendingModification, pendingPrompt, plan, result, tool]);
 
   return (
     <div className="flex h-full flex-col bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950">
@@ -99,6 +231,25 @@ const CreativeGenerator = ({ tool, description }: CreativeGeneratorProps) => {
             hasResult={Boolean(result)}
             history={history}
           />
+
+          {plan && phase === "planning" && (
+            <GenerationPlanView
+              plan={plan}
+              onConfirm={handleConfirmPlan}
+              onEdit={handleEditPlan}
+              confirmLabel="Valider le plan et générer"
+              isConfirming={isLoading}
+            />
+          )}
+
+          {(phase === "generating" || executionSteps.length > 0 || statusHistory.length > 0) && (
+            <GenerationProgress
+              steps={executionSteps}
+              statusMessage={statusMessage}
+              history={statusHistory}
+              phase={phase}
+            />
+          )}
 
           <ResultDisplay result={result} history={history} />
         </div>

--- a/src/components/GenerationPlanView.tsx
+++ b/src/components/GenerationPlanView.tsx
@@ -1,0 +1,106 @@
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import type { GenerationPlan } from "@/types/plan";
+import { BadgeCheck, CheckCircle2, Edit3, TriangleAlert } from "lucide-react";
+
+interface GenerationPlanViewProps {
+  plan: GenerationPlan;
+  onConfirm: () => void;
+  onEdit: () => void;
+  confirmLabel?: string;
+  isConfirming?: boolean;
+}
+
+const GenerationPlanView = ({
+  plan,
+  onConfirm,
+  onEdit,
+  confirmLabel = "Valider le plan et lancer la génération",
+  isConfirming = false,
+}: GenerationPlanViewProps) => (
+  <div className="flex h-full flex-col bg-background/70">
+    <div className="border-b border-border/40 px-5 py-4">
+      <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Plan d'action proposé</p>
+      <h3 className="mt-1 text-lg font-semibold text-foreground">{plan.title}</h3>
+      <p className="mt-2 text-sm text-muted-foreground">{plan.summary}</p>
+    </div>
+
+    <ScrollArea className="flex-1 px-5 py-4">
+      <div className="space-y-4">
+        {plan.sections.map((section) => (
+          <Card key={section.title} className="border-border/40 bg-background/80">
+            <div className="border-b border-border/30 px-4 py-3">
+              <h4 className="text-sm font-semibold text-foreground">{section.title}</h4>
+              <p className="mt-1 text-xs text-muted-foreground">{section.objective}</p>
+            </div>
+            <div className="space-y-3 px-4 py-3">
+              {section.steps.map((step) => (
+                <div key={step.id} className="rounded-lg border border-border/40 bg-muted/10 p-3">
+                  <p className="flex items-center gap-2 text-sm font-medium text-foreground">
+                    <BadgeCheck className="h-4 w-4 text-primary" />
+                    {step.title}
+                  </p>
+                  <p className="mt-1 text-xs text-muted-foreground">{step.description}</p>
+                  {step.deliverable && (
+                    <p className="mt-2 text-xs font-medium text-foreground/80">
+                      Livrable : <span className="text-muted-foreground">{step.deliverable}</span>
+                    </p>
+                  )}
+                </div>
+              ))}
+            </div>
+          </Card>
+        ))}
+
+        <Card className="border-border/30 bg-muted/10">
+          <div className="border-b border-border/30 px-4 py-3">
+            <p className="flex items-center gap-2 text-sm font-semibold text-foreground">
+              <CheckCircle2 className="h-4 w-4 text-primary" />
+              Critères de réussite
+            </p>
+          </div>
+          <ul className="space-y-2 px-5 py-4 text-sm text-muted-foreground">
+            {plan.successCriteria.map((criterion) => (
+              <li key={criterion} className="flex items-start gap-2">
+                <span className="mt-[6px] h-1.5 w-1.5 rounded-full bg-primary/60" />
+                <span>{criterion}</span>
+              </li>
+            ))}
+          </ul>
+        </Card>
+
+        {plan.cautions && plan.cautions.length > 0 && (
+          <Card className="border-border/30 bg-amber-500/5">
+            <div className="border-b border-border/30 px-4 py-3">
+              <p className="flex items-center gap-2 text-sm font-semibold text-foreground">
+                <TriangleAlert className="h-4 w-4 text-amber-400" />
+                Points de vigilance
+              </p>
+            </div>
+            <ul className="space-y-2 px-5 py-4 text-sm text-muted-foreground">
+              {plan.cautions.map((caution) => (
+                <li key={caution} className="flex items-start gap-2">
+                  <span className="mt-[6px] h-1.5 w-1.5 rounded-full bg-amber-400/60" />
+                  <span>{caution}</span>
+                </li>
+              ))}
+            </ul>
+          </Card>
+        )}
+      </div>
+    </ScrollArea>
+
+    <div className="flex items-center justify-between gap-3 border-t border-border/40 bg-background/80 px-5 py-4">
+      <Button variant="ghost" size="sm" onClick={onEdit} className="gap-2 text-muted-foreground">
+        <Edit3 className="h-4 w-4" />
+        Modifier le brief
+      </Button>
+      <Button onClick={onConfirm} disabled={isConfirming} className="gap-2">
+        {isConfirming ? "Validation en cours…" : confirmLabel}
+      </Button>
+    </div>
+  </div>
+);
+
+export default GenerationPlanView;

--- a/src/components/GenerationProgress.tsx
+++ b/src/components/GenerationProgress.tsx
@@ -1,0 +1,99 @@
+import { Card } from "@/components/ui/card";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import type { PlanExecutionStep, PlanStepStatus } from "@/types/plan";
+import { CheckCircle2, Loader2, Pause, Timer } from "lucide-react";
+
+const statusStyles: Record<PlanStepStatus, string> = {
+  pending: "border-border/40 bg-background/40 text-muted-foreground",
+  active: "border-primary/40 bg-primary/5 text-primary",
+  done: "border-emerald-500/40 bg-emerald-500/10 text-emerald-400",
+};
+
+interface GenerationProgressProps {
+  steps: PlanExecutionStep[];
+  statusMessage?: string;
+  history?: string[];
+  phase: "idle" | "planning" | "generating" | "complete";
+}
+
+const iconForStatus = (status: PlanStepStatus) => {
+  if (status === "active") {
+    return <Loader2 className="h-4 w-4 animate-spin" />;
+  }
+  if (status === "done") {
+    return <CheckCircle2 className="h-4 w-4" />;
+  }
+  return <Timer className="h-4 w-4" />;
+};
+
+const GenerationProgress = ({ steps, statusMessage, history = [], phase }: GenerationProgressProps) => {
+  const currentLabel =
+    phase === "generating"
+      ? statusMessage || "Génération en cours…"
+      : phase === "complete"
+        ? "Génération terminée"
+        : phase === "planning"
+          ? "Plan en attente de validation"
+          : "Prêt pour une nouvelle génération";
+
+  return (
+    <div className="space-y-3 p-4">
+      <Card className="border-border/30 bg-background/70">
+        <div className="flex items-center justify-between gap-3 border-b border-border/30 px-4 py-3">
+          <div>
+            <p className="text-sm font-semibold text-foreground">Progression</p>
+            <p className="text-xs text-muted-foreground">{currentLabel}</p>
+          </div>
+          {phase === "planning" && <Pause className="h-4 w-4 text-muted-foreground" />}
+        </div>
+        <ScrollArea className="max-h-64 px-4 py-3">
+          <ul className="space-y-3">
+            {steps.map((step) => (
+              <li
+                key={`${step.section}-${step.id}`}
+                className={`rounded-lg border p-3 transition ${statusStyles[step.status]}`}
+              >
+                <div className="flex items-center gap-2 text-sm font-medium">
+                  {iconForStatus(step.status)}
+                  <span>{step.title}</span>
+                </div>
+                <p className="mt-1 text-xs text-muted-foreground">{step.section}</p>
+                <p className="mt-1 text-xs text-muted-foreground/80">{step.description}</p>
+                {step.deliverable && (
+                  <p className="mt-2 text-[11px] uppercase tracking-wide text-muted-foreground/70">
+                    Livrable : {step.deliverable}
+                  </p>
+                )}
+              </li>
+            ))}
+            {!steps.length && (
+              <li className="rounded-lg border border-dashed border-border/40 bg-muted/10 p-4 text-center text-sm text-muted-foreground">
+                Aucun travail lancé pour le moment.
+              </li>
+            )}
+          </ul>
+        </ScrollArea>
+      </Card>
+
+      {history.length > 0 && (
+        <Card className="border-border/30 bg-background/60">
+          <div className="border-b border-border/30 px-4 py-2">
+            <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Journal</p>
+          </div>
+          <div className="px-4 py-3 text-xs text-muted-foreground">
+            <ul className="space-y-2">
+              {history.map((entry, index) => (
+                <li key={`${entry}-${index}`} className="flex items-start gap-2">
+                  <span className="mt-[6px] h-1.5 w-1.5 rounded-full bg-primary/50" />
+                  <span>{entry}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </Card>
+      )}
+    </div>
+  );
+};
+
+export default GenerationProgress;

--- a/src/components/ProjectSandpack.tsx
+++ b/src/components/ProjectSandpack.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import {
   SandpackLayout,
   SandpackPreview,
@@ -8,15 +8,26 @@ import {
 } from "@codesandbox/sandpack-react";
 import type { GeneratedFile } from "@/types/result";
 import { Card } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Code2, Columns, Loader2, Monitor } from "lucide-react";
 
 interface ProjectSandpackProps {
   files: GeneratedFile[];
   activeFile?: string;
+  isGenerating?: boolean;
 }
 
 const normalizeSandpackPath = (path: string) => (path.startsWith("/") ? path : `/${path}`);
 
-const ProjectSandpack = ({ files, activeFile }: ProjectSandpackProps) => {
+const LoaderOverlay = () => (
+  <div className="pointer-events-none flex flex-col items-center gap-2 text-center text-sm text-muted-foreground">
+    <Loader2 className="h-6 w-6 animate-spin text-primary" />
+    <p className="font-medium text-foreground">Génération du projet…</p>
+    <p className="text-xs text-muted-foreground">Le code est en cours d'écriture et la prévisualisation se mettra à jour automatiquement.</p>
+  </div>
+);
+
+const ProjectSandpack = ({ files, activeFile, isGenerating = false }: ProjectSandpackProps) => {
   const sandpackFiles = useMemo(() => {
     if (!files.length) return undefined;
 
@@ -26,6 +37,11 @@ const ProjectSandpack = ({ files, activeFile }: ProjectSandpackProps) => {
       return accumulator;
     }, {});
   }, [files]);
+
+  const [viewMode, setViewMode] = useState<"split" | "code" | "preview">("split");
+
+  const showCode = viewMode !== "preview";
+  const showPreview = viewMode !== "code";
 
   if (!files.length || !sandpackFiles) {
     return (
@@ -38,19 +54,59 @@ const ProjectSandpack = ({ files, activeFile }: ProjectSandpackProps) => {
   const defaultActiveFile = activeFile ? normalizeSandpackPath(activeFile) : Object.keys(sandpackFiles)[0];
 
   return (
-    <div className="flex h-full flex-col">
-      <div className="border-b border-border/40 px-6 py-4">
-        <p className="text-sm font-semibold text-muted-foreground">Code & Preview live</p>
+    <div className="relative flex h-full flex-col">
+      <div className="flex items-center justify-between gap-3 border-b border-border/40 px-6 py-4">
+        <p className="text-sm font-semibold text-muted-foreground">Espace de génération live</p>
+        <div className="flex items-center gap-2">
+          <Button
+            size="sm"
+            variant={viewMode === "split" ? "default" : "outline"}
+            onClick={() => setViewMode("split")}
+            className="gap-2"
+          >
+            <Columns className="h-4 w-4" />
+            Split
+          </Button>
+          <Button
+            size="sm"
+            variant={viewMode === "code" ? "default" : "outline"}
+            onClick={() => setViewMode("code")}
+            className="gap-2"
+          >
+            <Code2 className="h-4 w-4" />
+            Code
+          </Button>
+          <Button
+            size="sm"
+            variant={viewMode === "preview" ? "default" : "outline"}
+            onClick={() => setViewMode("preview")}
+            className="gap-2"
+          >
+            <Monitor className="h-4 w-4" />
+            Preview
+          </Button>
+        </div>
       </div>
-      <div className="flex-1 min-h-0 bg-background/40">
+      <div className="relative flex-1 min-h-0 bg-background/40">
         <SandpackProvider template="react-ts" files={sandpackFiles} options={{ activeFile: defaultActiveFile }}>
           <SandpackThemeProvider>
             <SandpackLayout style={{ height: "100%" }}>
-              <SandpackCodeEditor style={{ height: "100%" }} showTabs showLineNumbers />
-              <SandpackPreview style={{ height: "100%" }} />
+              {showCode && (
+                <SandpackCodeEditor
+                  style={{ height: "100%", display: showPreview ? "block" : "flex" }}
+                  showTabs
+                  showLineNumbers
+                />
+              )}
+              {showPreview && <SandpackPreview style={{ height: "100%" }} />}
             </SandpackLayout>
           </SandpackThemeProvider>
         </SandpackProvider>
+        {isGenerating && (
+          <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-3 bg-background/60 backdrop-blur">
+            <LoaderOverlay />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/lib/content-generators.ts
+++ b/src/lib/content-generators.ts
@@ -1,4 +1,5 @@
 import type { GeneratedResult } from "@/types/result";
+import type { GenerationPlan, PlanSection, PlanStep } from "@/types/plan";
 
 export type CreativeTool = "image" | "music" | "agent" | "game";
 
@@ -27,6 +28,518 @@ const simpleHash = (value: string) => {
 
 const pick = <T,>(items: T[], hash: number, offset: number) =>
   items[(hash + offset) % items.length];
+
+const detectKeyword = (prompt: string, mapping: Array<[RegExp, string]>, fallback: string) => {
+  const lowered = prompt.toLowerCase();
+  for (const [regex, value] of mapping) {
+    if (regex.test(lowered)) {
+      return value;
+    }
+  }
+  return fallback;
+};
+
+const extractColors = (prompt: string) => {
+  const lowered = prompt.toLowerCase();
+  const entries: Array<[RegExp, string]> = [
+    [/(bleu|azur|cobalt)/, "bleue"],
+    [/(violet|mauve|pourpre)/, "violette"],
+    [/(vert|émeraude|menthe)/, "verte"],
+    [/(rouge|cramoisi|bordeaux)/, "rouge"],
+    [/(rose|fuchsia|magenta)/, "rose"],
+    [/(orange|ambre|cuivre)/, "orangée"],
+    [/(dor[ée]|or|gold)/, "dorée"],
+    [/(argent|métal|chrome)/, "argentée"],
+    [/(noir|sombre|charbon)/, "sombre"],
+    [/(blanc|clair|ivoire)/, "lumineuse"],
+  ];
+
+  const detected = entries
+    .filter(([regex]) => regex.test(lowered))
+    .map(([, value]) => value);
+
+  if (!detected.length) return "harmonie contrastée";
+  if (detected.length === 1) return `palette ${detected[0]}`;
+  return `palette ${detected[0]} et ${detected[1]}`;
+};
+
+const createImagePlan = (prompt: string, modification?: string): GenerationPlan => {
+  const subject = detectKeyword(
+    prompt,
+    [
+      [/(produit|packshot|marchand)/, "mise en scène produit"],
+      [/(portrait|visage|personnage|personne)/, "portrait expressif"],
+      [/(paysage|nature|montagne|mer|forêt)/, "paysage immersif"],
+      [/(architecture|ville|urbain)/, "architecture stylisée"],
+    ],
+    "composition conceptuelle",
+  );
+  const mood = detectKeyword(
+    prompt,
+    [
+      [/(sombre|dramatique|noir)/, "ambiance sombre cinématique"],
+      [/(lumineux|clair|aérien|soleil)/, "ambiance lumineuse et positive"],
+      [/(futuriste|néon|cyber|synthwave)/, "ambiance futuriste aux néons"],
+      [/(mystérieux|onirique|fantastique)/, "ambiance onirique et mystérieuse"],
+    ],
+    "ambiance équilibrée",
+  );
+  const style = detectKeyword(
+    prompt,
+    [
+      [/(aquarelle|gouache)/, "style aquarelle"],
+      [/(huile|peinture)/, "style peinture digitale"],
+      [/(vectoriel|flat|minimal)/, "style vectoriel minimaliste"],
+      [/(3d|isométrique|low poly)/, "style 3D isométrique"],
+      [/(photo|photographique|réaliste)/, "style photo-réaliste"],
+    ],
+    "style illustratif moderne",
+  );
+  const perspective = detectKeyword(
+    prompt,
+    [
+      [/(plongée|vue du dessus)/, "vue en plongée"],
+      [/(contre[- ]plongée|imposant)/, "contre-plongée dramatique"],
+      [/(panoramique|large|cinémascope)/, "cadre large panoramique"],
+    ],
+    "cadre frontal équilibré",
+  );
+  const palette = extractColors(prompt);
+
+  const sections: PlanSection[] = [
+    {
+      title: "Analyse du brief",
+      objective: "Clarifier sujet, ambiance et contraintes avant de produire l'image.",
+      steps: [
+        {
+          id: "subject",
+          title: "Identifier le sujet clé",
+          description: `Mettre l'accent sur ${subject} avec ${perspective}.`,
+          deliverable: "Sujet cadré",
+        },
+        {
+          id: "style",
+          title: "Valider le style",
+          description: `Confirmer un ${style} cohérent dans ${mood}.`,
+          deliverable: "Références visuelles",
+        },
+        {
+          id: "palette",
+          title: "Lister la palette",
+          description: `Déployer une ${palette} adaptée au brief.`,
+          deliverable: "Palette finale",
+        },
+      ],
+    },
+    {
+      title: "Composition et détails",
+      objective: "Structurer la scène puis affiner lumière et textures.",
+      steps: [
+        {
+          id: "composition",
+          title: "Esquisser la composition",
+          description: `Définir masses principales et profondeur selon ${perspective}.`,
+          deliverable: "Croquis composition",
+        },
+        {
+          id: "lighting",
+          title: "Placer la lumière",
+          description: `Installer une lumière ${mood.replace("ambiance ", "")}.`,
+          deliverable: "Schéma lumineux",
+        },
+        {
+          id: "details",
+          title: "Ajouter les détails",
+          description: "Intégrer textures, accessoires et décor pour soutenir le récit visuel.",
+          deliverable: "Détails finalisés",
+        },
+      ],
+    },
+    {
+      title: "Finitions",
+      objective: "Vérifier cohérence et préparer l'export final.",
+      steps: [
+        {
+          id: "grading",
+          title: "Uniformiser les couleurs",
+          description: "Appliquer un color grading léger pour harmoniser l'image.",
+          deliverable: "Palette harmonisée",
+        },
+        {
+          id: "export",
+          title: "Préparer le rendu",
+          description: "Exporter en haute définition, format adapté au support (PNG/WEBP).",
+          deliverable: "Fichier final",
+        },
+      ],
+    },
+  ];
+
+  const summarySuffix = modification ? ` (ajustement : ${modification})` : "";
+
+  return {
+    title: "Plan de génération d'image",
+    summary: `Créer une illustration ${style} centrée sur ${subject} dans ${mood}${summarySuffix}`,
+    sections,
+    successCriteria: [
+      "Sujet et ambiance fidèles au brief",
+      "Composition lisible avec profondeur",
+      "Palette harmonieuse et cohérente",
+    ],
+    cautions: [
+      "Respecter la perspective et les proportions des éléments",
+      "Adapter le niveau de détail selon le support d'utilisation",
+    ],
+  };
+};
+
+const createMusicPlan = (prompt: string, modification?: string): GenerationPlan => {
+  const atmosphere = detectKeyword(
+    prompt,
+    [
+      [/(calme|relax|ambient|lo[- ]?fi)/, "ambiance chill immersive"],
+      [/(énergique|dance|club|punchy)/, "ambiance énergique et entraînante"],
+      [/(cinématique|épique|orchestrale)/, "ambiance cinématique grandiose"],
+      [/(nostalgique|rétro|vintage)/, "ambiance rétro nostalgique"],
+    ],
+    "ambiance contemporaine équilibrée",
+  );
+  const tempo = detectKeyword(
+    prompt,
+    [
+      [/(lent|slow|downtempo)/, "72-88 BPM"],
+      [/(modéré|mid|groove)/, "92-108 BPM"],
+      [/(rapide|upbeat|dance)/, "118-128 BPM"],
+    ],
+    "100 BPM",
+  );
+  const instrumentation = detectKeyword(
+    prompt,
+    [
+      [/(percussions|tribal|organic)/, "percussions organiques et textures granulaires"],
+      [/(synth|electro|analog)/, "synthés analogiques pulsés"],
+      [/(acoustique|guitare|piano)/, "instrumentation acoustique intimiste"],
+    ],
+    "basse ronde et pads atmosphériques",
+  );
+
+  const sections: PlanSection[] = [
+    {
+      title: "Analyse musicale",
+      objective: "Comprendre l'univers sonore souhaité et cadrer les contraintes techniques.",
+      steps: [
+        {
+          id: "ambiance",
+          title: "Qualifier l'ambiance",
+          description: `Traduire ${atmosphere} avec un tempo ${tempo}.`,
+          deliverable: "Moodboard sonore",
+        },
+        {
+          id: "structure",
+          title: "Tracer la structure",
+          description: "Découper le morceau en intro, sections A/B, pont et outro.",
+          deliverable: "Plan de structure",
+        },
+      ],
+    },
+    {
+      title: "Composition",
+      objective: "Construire harmonie, motifs et transitions pour soutenir le récit musical.",
+      steps: [
+        {
+          id: "harmonie",
+          title: "Choisir l'harmonie",
+          description: "Déterminer tonalité et progression principale.",
+          deliverable: "Grille d'accords",
+        },
+        {
+          id: "motifs",
+          title: "Écrire les motifs",
+          description: `Créer un hook mémorable et un motif de basse ${instrumentation}.`,
+          deliverable: "Motifs principaux",
+        },
+        {
+          id: "transitions",
+          title: "Préparer les transitions",
+          description: "Utiliser montées, impacts et textures pour relier les sections.",
+          deliverable: "Automation des transitions",
+        },
+      ],
+    },
+    {
+      title: "Production & mix",
+      objective: "Arranger, mixer puis préparer l'export final.",
+      steps: [
+        {
+          id: "sound-design",
+          title: "Sélectionner le sound design",
+          description: "Composer un rack d'instruments cohérent (pads, percussions, lead).",
+          deliverable: "Palette sonore",
+        },
+        {
+          id: "mix",
+          title: "Mixer les stems",
+          description: "Équilibrer dynamiques, panoramiques et effets temporels.",
+          deliverable: "Mix stéréo équilibré",
+        },
+        {
+          id: "master",
+          title: "Préparer le master",
+          description: "Appliquer compression glue, EQ douce et limiteur -14 LUFS.",
+          deliverable: "Master prêt à diffuser",
+        },
+      ],
+    },
+  ];
+
+  const summarySuffix = modification ? ` (modification : ${modification})` : "";
+
+  return {
+    title: "Plan de composition musicale",
+    summary: `Composer une pièce à ${tempo} inspirée par ${atmosphere}${summarySuffix}`,
+    sections,
+    successCriteria: [
+      "Structure narrative cohérente",
+      "Motif mémorable aligné sur l'ambiance",
+      "Mix équilibré prêt pour diffusion",
+    ],
+    cautions: [
+      "Adapter la durée au format de diffusion visé",
+      "Vérifier les droits si des références sont explicitement citées",
+    ],
+  };
+};
+
+const createAgentPlan = (prompt: string, modification?: string): GenerationPlan => {
+  const role = detectKeyword(
+    prompt,
+    [
+      [/(marketing|growth|acquisition)/, "planificateur marketing"],
+      [/(produit|product|roadmap)/, "assistant produit stratégique"],
+      [/(support|client|service)/, "agent support client proactif"],
+      [/(data|analyse|analyst)/, "analyste de données décisionnel"],
+    ],
+    "assistant polyvalent",
+  );
+  const tone = detectKeyword(
+    prompt,
+    [
+      [/(amical|chaleureux|humain)/, "ton empathique"],
+      [/(formel|professionnel)/, "ton professionnel cadré"],
+      [/(direct|percutant)/, "ton direct orienté action"],
+    ],
+    "ton consultatif",
+  );
+  const tooling = detectKeyword(
+    prompt,
+    [
+      [/(notion|documentation)/, "Notion pour la base de connaissance"],
+      [/(figma|design)/, "Figma pour la collaboration visuelle"],
+      [/(slack|communication)/, "Slack pour l'orchestration des échanges"],
+      [/(linear|jira|projet)/, "Linear pour le pilotage des tâches"],
+    ],
+    "Stack modulaire (Notion + Slack + Google Suite)",
+  );
+
+  const sections: PlanSection[] = [
+    {
+      title: "Cadrage du rôle",
+      objective: "Transformer le brief en missions concrètes pour l'agent.",
+      steps: [
+        {
+          id: "mission",
+          title: "Formuler la mission",
+          description: `Positionner ${role} et définir ses objectifs prioritaires.`,
+          deliverable: "Charte de mission",
+        },
+        {
+          id: "ton",
+          title: "Aligner le ton",
+          description: `Paramétrer un ${tone} adapté à la cible.`,
+          deliverable: "Guide de tonalité",
+        },
+      ],
+    },
+    {
+      title: "Boucle opérationnelle",
+      objective: "Définir les routines et outils utilisés par l'agent.",
+      steps: [
+        {
+          id: "inputs",
+          title: "Cartographier les entrées",
+          description: "Lister les canaux d'information et signaux déclencheurs.",
+          deliverable: "Sources et signaux",
+        },
+        {
+          id: "workflow",
+          title: "Structurer le workflow",
+          description: "Détailler la séquence Observer → Analyser → Agir → Reporter.",
+          deliverable: "Workflow détaillé",
+        },
+        {
+          id: "outils",
+          title: "Choisir les outils",
+          description: `Sélectionner ${tooling} et définir les permissions.`,
+          deliverable: "Stack outils configurée",
+        },
+      ],
+    },
+    {
+      title: "Suivi & amélioration",
+      objective: "Prévoir les métriques et le handoff humain.",
+      steps: [
+        {
+          id: "kpi",
+          title: "Définir les KPIs",
+          description: "Identifier 3 indicateurs pour mesurer l'impact.",
+          deliverable: "Tableau de bord KPI",
+        },
+        {
+          id: "handoff",
+          title: "Planifier le handoff",
+          description: "Organiser la reprise humaine pour les demandes complexes.",
+          deliverable: "Process de reprise",
+        },
+      ],
+    },
+  ];
+
+  const summarySuffix = modification ? ` (ajustement : ${modification})` : "";
+
+  return {
+    title: "Plan de conception d'agent",
+    summary: `Structurer ${role} avec ${tone}${summarySuffix}`,
+    sections,
+    successCriteria: [
+      "Objectifs mesurables définis",
+      "Workflow clair avec outils associés",
+      "Routine de reporting pour amélioration continue",
+    ],
+    cautions: [
+      "Prévoir une supervision humaine avant mise en production",
+      "Documenter les limites de l'agent pour cadrer les attentes",
+    ],
+  };
+};
+
+const createGamePlan = (prompt: string, modification?: string): GenerationPlan => {
+  const genre = detectKeyword(
+    prompt,
+    [
+      [/(rogue|survie|procédural)/, "rogue-lite stratégique"],
+      [/(puzzle|énigme|logic)/, "puzzle narratif"],
+      [/(gestion|city|tycoon)/, "jeu de gestion systémique"],
+      [/(action|combat|fps|tps)/, "action aventure immersive"],
+    ],
+    "jeu d'exploration narratif",
+  );
+  const camera = detectKeyword(
+    prompt,
+    [
+      [/(vue du dessus|top-down)/, "vue top-down"],
+      [/(isométrique)/, "caméra isométrique"],
+      [/(à la première personne|fps)/, "vue subjective"],
+      [/(troisième personne|tps)/, "caméra troisième personne"],
+    ],
+    "caméra dynamique",
+  );
+  const progression = detectKeyword(
+    prompt,
+    [
+      [/(campagne|histoire|narratif)/, "progression narrative chapitre par chapitre"],
+      [/(coop|multijoueur)/, "progression coopérative synchronisée"],
+      [/(compétitif|pvp)/, "progression compétitive basée sur le classement"],
+    ],
+    "progression par boucles de missions",
+  );
+
+  const sections: PlanSection[] = [
+    {
+      title: "Fondations du concept",
+      objective: "Définir l'expérience de jeu et la proposition de valeur.",
+      steps: [
+        {
+          id: "pitch",
+          title: "Synthétiser le pitch",
+          description: `Formuler ${genre} avec ${camera}.`,
+          deliverable: "Pitch en une phrase",
+        },
+        {
+          id: "audience",
+          title: "Identifier l'audience",
+          description: "Déterminer le joueur cible et ses motivations.",
+          deliverable: "Persona joueur",
+        },
+      ],
+    },
+    {
+      title: "Boucle de gameplay",
+      objective: "Designer la boucle minute → session → métagame.",
+      steps: [
+        {
+          id: "minute",
+          title: "Boucle courte",
+          description: "Décrire les actions répétées (explorer, résoudre, combattre).",
+          deliverable: "Loop minute documentée",
+        },
+        {
+          id: "session",
+          title: "Boucle de session",
+          description: `Planifier la progression ${progression}.`,
+          deliverable: "Loop session",
+        },
+        {
+          id: "meta",
+          title: "Métagame",
+          description: "Imaginer les récompenses persistantes et améliorations.",
+          deliverable: "Système de progression",
+        },
+      ],
+    },
+    {
+      title: "Univers & production",
+      objective: "Décrire direction artistique et besoins techniques.",
+      steps: [
+        {
+          id: "worldbuilding",
+          title: "Esquisser l'univers",
+          description: "Définir ton, factions et arcs narratifs.",
+          deliverable: "Bible d'univers",
+        },
+        {
+          id: "tech",
+          title: "Lister les piliers techniques",
+          description: "Identifier moteurs, modules réseau et besoins IA.",
+          deliverable: "Backlog technique",
+        },
+        {
+          id: "roadmap",
+          title: "Étager la roadmap",
+          description: "Planifier préproduction, vertical slice, alpha et bêta.",
+          deliverable: "Roadmap haut niveau",
+        },
+      ],
+    },
+  ];
+
+  const summarySuffix = modification ? ` (évolution : ${modification})` : "";
+
+  return {
+    title: "Plan de concept jeu vidéo",
+    summary: `Imaginer ${genre} en ${camera} avec ${progression}${summarySuffix}`,
+    sections,
+    successCriteria: [
+      "Boucle de gameplay compréhensible",
+      "Progression et récompenses motivantes",
+      "Vision artistique cohérente",
+    ],
+    cautions: [
+      "Prioriser une vertical slice pour valider les sensations",
+      "Anticiper la charge de production selon la complexité technique",
+    ],
+  };
+};
+
 
 const generateImageResult = (options: GenerationOptions): GeneratedResult => {
   const { prompt, version, modification } = options;
@@ -222,3 +735,22 @@ export const generateCreativeResult = (
 };
 
 export const getCreativeToolLabel = (tool: CreativeTool) => TOOL_LABELS[tool];
+
+export const createCreativePlan = (
+  tool: CreativeTool,
+  prompt: string,
+  modification?: string,
+): GenerationPlan => {
+  switch (tool) {
+    case "image":
+      return createImagePlan(prompt, modification);
+    case "music":
+      return createMusicPlan(prompt, modification);
+    case "agent":
+      return createAgentPlan(prompt, modification);
+    case "game":
+      return createGamePlan(prompt, modification);
+    default:
+      return createImagePlan(prompt, modification);
+  }
+};

--- a/src/types/plan.ts
+++ b/src/types/plan.ts
@@ -1,0 +1,27 @@
+export type PlanStepStatus = "pending" | "active" | "done";
+
+export interface PlanStep {
+  id: string;
+  title: string;
+  description: string;
+  deliverable?: string;
+}
+
+export interface PlanSection {
+  title: string;
+  objective: string;
+  steps: PlanStep[];
+}
+
+export interface GenerationPlan {
+  title: string;
+  summary: string;
+  sections: PlanSection[];
+  successCriteria: string[];
+  cautions?: string[];
+}
+
+export interface PlanExecutionStep extends PlanStep {
+  section: string;
+  status: PlanStepStatus;
+}


### PR DESCRIPTION
## Summary
- introduce plan-first workflows for site and app generation with live progress, streaming file delivery, and export reset handling
- reuse the planning flow across creative tools with execution timelines and context-aware prompts for revisions
- add reusable plan review and progress components and enhance the Sandpack workspace with viewport toggles and overlays
- extend project and content generators with heuristic planning helpers shared through new plan types

## Testing
- npm run build *(fails: Rollup could not resolve @codesandbox/sandpack-react; existing dependency issue)*

------
https://chatgpt.com/codex/tasks/task_e_68dcd73061ec8323b9afc463a7c4d258