### PR TITLE
Improve generator dialog scrolling

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -158,18 +158,22 @@ const Index = () => {
       </section>
 
       <Dialog open={Boolean(activeTool)} onOpenChange={handleDialogChange}>
-        <DialogContent className="max-w-[1200px] w-full max-h-[90vh] overflow-hidden border border-white/10 bg-slate-950/95 p-0 backdrop-blur-xl">
-          {activeTool && activeDetail && (
-            isBuilder ? (
-              <SiteAppGenerator key={activeTool} mode={activeTool as SiteAppMode} />
-            ) : (
-              <CreativeGenerator
-                key={activeTool}
-                tool={activeTool as CreativeTool}
-                description={activeDetail.dialogDescription}
-              />
-            )
-          )}
+        <DialogContent className="max-w-[1200px] w-full h-[90vh] border border-white/10 bg-slate-950/95 p-0 backdrop-blur-xl">
+          <div className="h-full overflow-y-auto">
+            <div className="h-full">
+              {activeTool && activeDetail && (
+                isBuilder ? (
+                  <SiteAppGenerator key={activeTool} mode={activeTool as SiteAppMode} />
+                ) : (
+                  <CreativeGenerator
+                    key={activeTool}
+                    tool={activeTool as CreativeTool}
+                    description={activeDetail.dialogDescription}
+                  />
+                )
+              )}
+            </div>
+          </div>
         </DialogContent>
       </Dialog>
     </div>


### PR DESCRIPTION
## Summary
- replace the dialog max-height overflow setup with a fixed-height container and scrollable inner wrapper
- keep generator components wrapped in full-height containers so their internal sections can use available space

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcf122a9b88323953e867af7bc226e