### PR TITLE
Improve generator dialog scrolling

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -159,19 +159,21 @@ const Index = () => {
 
       <Dialog open={Boolean(activeTool)} onOpenChange={handleDialogChange}>
         <DialogContent className="max-w-[1200px] w-full h-[90vh] border border-white/10 bg-slate-950/95 p-0 backdrop-blur-xl">
-          <div className="h-full overflow-y-auto">
-            <div className="h-full">
-              {activeTool && activeDetail && (
-                isBuilder ? (
-                  <SiteAppGenerator key={activeTool} mode={activeTool as SiteAppMode} />
-                ) : (
-                  <CreativeGenerator
-                    key={activeTool}
-                    tool={activeTool as CreativeTool}
-                    description={activeDetail.dialogDescription}
-                  />
-                )
-              )}
+          <div className="flex h-full flex-col">
+            <div className="flex-1 overflow-y-auto">
+              <div className="h-full">
+                {activeTool && activeDetail && (
+                  isBuilder ? (
+                    <SiteAppGenerator key={activeTool} mode={activeTool as SiteAppMode} />
+                  ) : (
+                    <CreativeGenerator
+                      key={activeTool}
+                      tool={activeTool as CreativeTool}
+                      description={activeDetail.dialogDescription}
+                    />
+                  )
+                )}
+              </div>
             </div>
           </div>
         </DialogContent>


### PR DESCRIPTION
## Summary
- update the generator dialog content to dedicate full height and enable vertical scrolling
- keep generator components wrapped in full-height containers so their inner sections can use overflow behaviour

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dcf39891ec832395bbb5d89b9c3d47