### PR TITLE
Improve mobile layout responsiveness

### DIFF
--- a/src/components/ProjectFileTree.tsx
+++ b/src/components/ProjectFileTree.tsx
@@ -112,7 +112,7 @@ const ProjectFileTree = ({ files, activeFile, onSelect }: ProjectFileTreeProps) 
   };
 
   return (
-    <div className="flex h-full flex-col border-r border-border/50 bg-background/60">
+    <div className="flex h-full flex-col border-t border-border/50 bg-background/60 lg:border-t-0 lg:border-r">
       <div className="border-b border-border/40 px-4 py-3">
         <p className="text-sm font-semibold text-muted-foreground">Arborescence du projet</p>
       </div>

--- a/src/components/ProjectSandpack.tsx
+++ b/src/components/ProjectSandpack.tsx
@@ -54,8 +54,8 @@ const ProjectSandpack = ({ files, activeFile, isGenerating = false }: ProjectSan
   const defaultActiveFile = activeFile ? normalizeSandpackPath(activeFile) : Object.keys(sandpackFiles)[0];
 
   return (
-    <div className="relative flex h-full flex-col">
-      <div className="flex items-center justify-between gap-3 border-b border-border/40 px-6 py-4">
+    <div className="relative flex h-full flex-col border-t border-border/50 bg-background/60 lg:border-t-0">
+      <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border/40 px-4 py-4 sm:px-6">
         <p className="text-sm font-semibold text-muted-foreground">Espace de génération live</p>
         <div className="flex items-center gap-2">
           <Button

--- a/src/components/PromptSidebar.tsx
+++ b/src/components/PromptSidebar.tsx
@@ -54,7 +54,7 @@ const PromptSidebar = ({
   );
 
   return (
-    <div className="flex h-full flex-col border-r border-border/50 bg-background/60 backdrop-blur">
+    <div className="flex h-full flex-col border-b border-border/50 bg-background/60 backdrop-blur lg:border-b-0 lg:border-r">
       <div className="border-b border-border/40 px-5 py-4">
         <div className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wider text-muted-foreground">
           <Sparkles className="h-4 w-4" />

--- a/src/components/SiteAppGenerator.tsx
+++ b/src/components/SiteAppGenerator.tsx
@@ -288,7 +288,7 @@ const SiteAppGenerator = ({ mode }: SiteAppGeneratorProps) => {
 
   return (
     <div className="flex h-full w-full bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950">
-      <div className="grid h-full w-full grid-cols-[minmax(280px,340px)_minmax(280px,360px)_1fr] bg-background/60">
+      <div className="grid h-full w-full grid-cols-1 bg-background/60 max-lg:gap-6 max-lg:overflow-y-auto lg:grid-cols-[minmax(260px,320px)_minmax(260px,360px)_1fr] lg:overflow-hidden">
         <PromptSidebar
           prompt={prompt}
           onPromptChange={setPrompt}
@@ -308,7 +308,7 @@ const SiteAppGenerator = ({ mode }: SiteAppGeneratorProps) => {
           exportLabel="Télécharger le projet"
         />
 
-        <div className="flex h-full flex-col border-r border-border/50 bg-background/60">
+        <div className="flex h-full flex-col border-t border-border/50 bg-background/60 max-lg:border-l-0 max-lg:border-r-0 lg:border-t-0 lg:border-r">
           {phase === "planning" && plan ? (
             <GenerationPlanView
               plan={plan}
@@ -330,7 +330,11 @@ const SiteAppGenerator = ({ mode }: SiteAppGeneratorProps) => {
           )}
         </div>
 
-        <ProjectSandpack files={projectFiles} activeFile={activeFile} isGenerating={phase === "generating"} />
+        <ProjectSandpack
+          files={projectFiles}
+          activeFile={activeFile}
+          isGenerating={phase === "generating"}
+        />
       </div>
     </div>
   );

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -158,7 +158,7 @@ const Index = () => {
       </section>
 
       <Dialog open={Boolean(activeTool)} onOpenChange={handleDialogChange}>
-        <DialogContent className="max-w-[1200px] w-full h-[90vh] border border-white/10 bg-slate-950/95 p-0 backdrop-blur-xl">
+        <DialogContent className="flex h-[92vh] w-full max-w-[100vw] flex-col overflow-hidden border border-white/10 bg-slate-950/95 p-0 backdrop-blur-xl sm:h-[90vh] sm:max-w-[1200px]">
           <div className="flex h-full flex-col">
             <div className="flex-1 overflow-y-auto">
               <div className="h-full">


### PR DESCRIPTION
## Summary
- expand the generator dialog to use the full viewport width on phones and preserve vertical scrolling
- stack the builder workspace columns on small screens with responsive borders and padding
- update the live sandpack header to wrap controls on narrow viewports

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd6c92b2bc8323b0d06d291b7e6cc6