### PR TITLE
Allow collapsing project file tree

### DIFF
--- a/src/components/ProjectFileTree.tsx
+++ b/src/components/ProjectFileTree.tsx
@@ -1,13 +1,15 @@
 import { useMemo } from "react";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import type { GeneratedFile } from "@/types/result";
-import { Folder, FileText } from "lucide-react";
+import { Folder, FileText, PanelLeftClose } from "lucide-react";
 
 interface ProjectFileTreeProps {
   files: GeneratedFile[];
   activeFile?: string;
   onSelect: (path: string) => void;
+  onCollapse?: () => void;
 }
 
 interface TreeNode {
@@ -67,7 +69,7 @@ const buildTree = (files: GeneratedFile[]): TreeNode[] => {
   return root.children ?? [];
 };
 
-const ProjectFileTree = ({ files, activeFile, onSelect }: ProjectFileTreeProps) => {
+const ProjectFileTree = ({ files, activeFile, onSelect, onCollapse }: ProjectFileTreeProps) => {
   const tree = useMemo(() => buildTree(files), [files]);
 
   const renderNode = (node: TreeNode, depth = 0): JSX.Element => {
@@ -113,8 +115,21 @@ const ProjectFileTree = ({ files, activeFile, onSelect }: ProjectFileTreeProps) 
 
   return (
     <div className="flex h-full flex-col border-t border-border/50 bg-background/60 lg:border-t-0 lg:border-r">
-      <div className="border-b border-border/40 px-4 py-3">
+      <div className="flex items-center justify-between border-b border-border/40 px-4 py-3">
         <p className="text-sm font-semibold text-muted-foreground">Arborescence du projet</p>
+        {onCollapse && (
+          <Button
+            type="button"
+            size="sm"
+            variant="ghost"
+            className="gap-2 text-xs text-muted-foreground hover:text-foreground"
+            onClick={onCollapse}
+            disabled={!files.length}
+          >
+            <PanelLeftClose className="h-4 w-4" />
+            Masquer
+          </Button>
+        )}
       </div>
       <ScrollArea className="flex-1 px-3 py-4">
         {tree.length ? (

--- a/src/components/ProjectSandpack.tsx
+++ b/src/components/ProjectSandpack.tsx
@@ -9,12 +9,16 @@ import {
 import type { GeneratedFile } from "@/types/result";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Code2, Columns, Loader2, Monitor } from "lucide-react";
+import { Code2, Columns, Loader2, Monitor, PanelRightOpen } from "lucide-react";
+import { cn } from "@/lib/utils";
 
 interface ProjectSandpackProps {
   files: GeneratedFile[];
   activeFile?: string;
   isGenerating?: boolean;
+  className?: string;
+  isFileTreeCollapsed?: boolean;
+  onExpandFileTree?: () => void;
 }
 
 const normalizeSandpackPath = (path: string) => (path.startsWith("/") ? path : `/${path}`);
@@ -27,7 +31,14 @@ const LoaderOverlay = () => (
   </div>
 );
 
-const ProjectSandpack = ({ files, activeFile, isGenerating = false }: ProjectSandpackProps) => {
+const ProjectSandpack = ({
+  files,
+  activeFile,
+  isGenerating = false,
+  className,
+  isFileTreeCollapsed = false,
+  onExpandFileTree,
+}: ProjectSandpackProps) => {
   const sandpackFiles = useMemo(() => {
     if (!files.length) return undefined;
 
@@ -54,10 +65,16 @@ const ProjectSandpack = ({ files, activeFile, isGenerating = false }: ProjectSan
   const defaultActiveFile = activeFile ? normalizeSandpackPath(activeFile) : Object.keys(sandpackFiles)[0];
 
   return (
-    <div className="relative flex h-full flex-col border-t border-border/50 bg-background/60 lg:border-t-0">
+    <div className={cn("relative flex h-full flex-col border-t border-border/50 bg-background/60 lg:border-t-0", className)}>
       <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border/40 px-4 py-4 sm:px-6">
         <p className="text-sm font-semibold text-muted-foreground">Espace de génération live</p>
         <div className="flex items-center gap-2">
+          {isFileTreeCollapsed && onExpandFileTree && (
+            <Button size="sm" variant="outline" className="gap-2" onClick={onExpandFileTree}>
+              <PanelRightOpen className="h-4 w-4" />
+              Afficher l'arborescence
+            </Button>
+          )}
           <Button
             size="sm"
             variant={viewMode === "split" ? "default" : "outline"}


### PR DESCRIPTION
## Summary
- add collapse controls to the project file tree and reset its state when regenerating
- expand the live sandbox when the tree is hidden and provide a reopen button in the preview header

## Testing
- npm run lint *(fails: existing lint errors in shared UI files and tailwind config)*

------
https://chatgpt.com/codex/tasks/task_e_68dd739013908323988b6edba8b5510e