### PR TITLE
Handle missing steps in creative plan execution

### DIFF
--- a/src/components/CreativeGenerator.tsx
+++ b/src/components/CreativeGenerator.tsx
@@ -31,8 +31,8 @@ interface CreativeGeneratorProps {
 }
 
 const toExecutionSteps = (plan: GenerationPlan): PlanExecutionStep[] => {
-  const steps = plan.sections.flatMap((section) =>
-    section.steps.map((step) => ({
+  const steps = (plan.sections ?? []).flatMap((section) =>
+    (section.steps ?? []).map((step) => ({
       ...step,
       section: section.title,
       status: "pending" as PlanStepStatus,


### PR DESCRIPTION
## Summary
- prevent runtime crashes during creative generation by tolerating missing plan sections and steps when preparing execution steps

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ddfbf00d3c8323b160634e01b5375b