### PR TITLE
Add game creative tool label fallback

### DIFF
--- a/src/components/CreativeGenerator.tsx
+++ b/src/components/CreativeGenerator.tsx
@@ -96,7 +96,7 @@ const CreativeGenerator = ({ tool, description }: CreativeGeneratorProps) => {
     setStatusMessage("");
   }, [clearTimers]);
 
-  const label = useMemo(() => getCreativeToolLabel(tool), [tool]);
+  const label = useMemo(() => getCreativeToolLabel(tool) ?? tool, [tool]);
 
   const handlePlanRequest = useCallback(
     (basePrompt: string, modification?: string) => {

--- a/src/lib/content-generators.ts
+++ b/src/lib/content-generators.ts
@@ -3,7 +3,7 @@ import type { GenerationPlan, PlanSection } from "@/types/plan";
 import type { ImageAspectRatio, ImageGenerationSettings } from "@/types/image";
 import { supabase } from "@/integrations/supabase/client";
 
-export type CreativeTool = "image" | "music" | "agent";
+export type CreativeTool = "image" | "music" | "agent" | "game";
 
 interface GenerationOptions {
   prompt: string;
@@ -22,6 +22,7 @@ const TOOL_LABELS: Record<CreativeTool, string> = {
   image: "Générateur d'image",
   music: "Générateur de musique",
   agent: "Générateur d'agents",
+  game: "Générateur de jeux vidéo",
 };
 
 const simpleHash = (value: string) => {
@@ -1329,7 +1330,8 @@ export const requestCreativeResult = async (
   };
 };
 
-export const getCreativeToolLabel = (tool: CreativeTool) => TOOL_LABELS[tool];
+export const getCreativeToolLabel = (tool: CreativeTool) =>
+  TOOL_LABELS[tool] ?? tool;
 
 export const requestCreativePlan = async (
   tool: CreativeTool,


### PR DESCRIPTION
## Summary
- add the "game" creative tool label so the UI can render a localized name
- fall back to the tool key when resolving creative tool labels to avoid undefined values
- ensure the creative generator component always passes a string label to the prompt input

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ddff9f86ec8323a585a60c56b5c61a