### PR TITLE
Use AI backend for game builder and adjust iframe sandbox

### DIFF
--- a/src/components/CodeViewer.tsx
+++ b/src/components/CodeViewer.tsx
@@ -136,7 +136,7 @@ const CodeViewer = ({ code, category }: CodeViewerProps) => {
             srcDoc={code}
             className="w-full h-[500px]"
             title="Preview"
-            sandbox="allow-scripts allow-same-origin"
+            sandbox="allow-scripts allow-pointer-lock"
           />
         </div>
       )}


### PR DESCRIPTION
## Summary
- replace the local prototype generator with calls to the Supabase edge function so the game builder produces full game code from the AI model
- persist the AI-generated code while still surfacing design summaries, and add loading guards plus toasts for generation, chat updates, and quick regenerations
- tighten iframe sandboxing for previews to avoid the allow-scripts/allow-same-origin warning while keeping pointer lock support

## Testing
- `npm run lint` *(fails: existing lint errors in ui components and config)*

------
https://chatgpt.com/codex/tasks/task_e_68de1c595cc48323a33dcfd0666995c2