### PR TITLE
feat: enable React site generation with editable preview

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "vite_react_shadcn_ts",
       "version": "0.0.0",
       "dependencies": {
+        "@babel/standalone": "^7.26.0",
         "@hookform/resolvers": "^3.10.0",
         "@radix-ui/react-accordion": "^1.2.11",
         "@radix-ui/react-alert-dialog": "^1.1.14",
@@ -86,7 +87,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -135,6 +135,15 @@
       "version": "7.28.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.2.tgz",
       "integrity": "sha512-KHp2IflsnGywDjBWDkR9iEqiWSpc8GIi0lgTT3mOElT0PP1tG26P4tmFI2YvAdzgq9RGyoHZQEIEdZy6Ec5xCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/standalone": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/standalone/-/standalone-7.28.4.tgz",
+      "integrity": "sha512-Qc1BNCfuJZBKs2SC5lqRmSYOw7Ka0X7urZQ7oVsGIax4eGDUIHX+CDg752N4jDxC2rbBh3li098ReGOtjT0x4g==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -850,7 +859,6 @@
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
       "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "string-width": "^5.1.2",
@@ -868,7 +876,6 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
       "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/set-array": "^1.2.1",
@@ -883,7 +890,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -893,7 +899,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
       "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -903,14 +908,12 @@
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
       "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
       "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -921,7 +924,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -935,7 +937,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -945,7 +946,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -959,7 +959,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -3036,7 +3035,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
@@ -3382,7 +3381,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.1.0.tgz",
       "integrity": "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3395,7 +3393,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3411,14 +3408,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -3432,7 +3427,6 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -3496,14 +3490,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -3527,7 +3519,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -3583,7 +3574,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -3661,7 +3651,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -3686,7 +3675,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -3735,7 +3723,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3748,7 +3735,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/comma-separated-tokens": {
@@ -3765,7 +3751,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -3788,7 +3773,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -3802,7 +3786,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -3989,14 +3972,12 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/dom-helpers": {
@@ -4013,7 +3994,6 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
@@ -4055,7 +4035,6 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/esbuild": {
@@ -4334,7 +4313,6 @@
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
       "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -4351,7 +4329,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -4378,7 +4355,6 @@
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
       "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -4414,7 +4390,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -4465,7 +4440,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.0.tgz",
       "integrity": "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "cross-spawn": "^7.0.0",
@@ -4504,7 +4478,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -4519,7 +4492,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4538,7 +4510,6 @@
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
       "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -4559,7 +4530,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -4572,7 +4542,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
       "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -4582,7 +4551,6 @@
       "version": "9.0.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
       "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -4628,7 +4596,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4775,7 +4742,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -4788,7 +4754,6 @@
       "version": "2.15.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
       "integrity": "sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -4814,7 +4779,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4824,7 +4788,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4834,7 +4797,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -4857,7 +4819,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -4873,14 +4834,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/jackspeak": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
       "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -4896,7 +4855,6 @@
       "version": "1.21.6",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.6.tgz",
       "integrity": "sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==",
-      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -4991,7 +4949,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -5004,7 +4961,6 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -5528,7 +5484,6 @@
       "version": "10.4.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/lucide-react": {
@@ -5553,7 +5508,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -5563,7 +5517,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -5590,7 +5543,6 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
       "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -5607,7 +5559,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -5619,7 +5570,6 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5662,7 +5612,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5691,7 +5640,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -5751,7 +5699,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-      "dev": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/pako": {
@@ -5805,7 +5752,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5815,14 +5761,12 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
       "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -5839,14 +5783,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -5859,7 +5801,6 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5869,7 +5810,6 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.6.tgz",
       "integrity": "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -5879,7 +5819,6 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5908,7 +5847,6 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -5926,7 +5864,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
       "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "camelcase-css": "^2.0.1"
@@ -5946,7 +5883,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
       "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5982,7 +5918,6 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -6008,7 +5943,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -6022,7 +5956,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/prelude-ls": {
@@ -6094,7 +6027,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6335,7 +6267,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -6360,7 +6291,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -6429,7 +6359,6 @@
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
       "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.13.0",
@@ -6457,7 +6386,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -6504,7 +6432,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6562,7 +6489,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -6575,7 +6501,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6585,7 +6510,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -6608,7 +6532,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -6637,7 +6560,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
       "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -6656,7 +6578,6 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -6671,7 +6592,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6681,14 +6601,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -6701,7 +6619,6 @@
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
       "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^6.0.1"
@@ -6718,7 +6635,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -6731,7 +6647,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6754,7 +6669,6 @@
       "version": "3.35.0",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.0.tgz",
       "integrity": "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -6790,7 +6704,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6813,7 +6726,6 @@
       "version": "3.4.17",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -6860,7 +6772,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -6870,7 +6781,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
@@ -6889,7 +6799,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -6921,7 +6830,6 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/tslib": {
@@ -7201,7 +7109,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -7227,7 +7134,6 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
       "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -7246,7 +7152,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -7264,7 +7169,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -7274,14 +7178,12 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrap-ansi-cjs/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -7296,7 +7198,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -7309,7 +7210,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
       "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -7352,7 +7252,6 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.0.tgz",
       "integrity": "sha512-a6ae//JvKDEra2kdi1qzCyrJW/WZCgFi8ydDV+eXExl95t+5R+ijnqHJbz9tmMh8FUjx3iv2fCQ4dclAQlO2UQ==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@babel/standalone": "^7.26.0",
     "@hookform/resolvers": "^3.10.0",
     "@radix-ui/react-accordion": "^1.2.11",
     "@radix-ui/react-alert-dialog": "^1.1.14",

--- a/src/components/WebsiteBuilderWorkspace.tsx
+++ b/src/components/WebsiteBuilderWorkspace.tsx
@@ -1,12 +1,16 @@
-import { useEffect, useMemo, useState, type KeyboardEvent } from "react";
+import { useCallback, useEffect, useMemo, useState, type KeyboardEvent } from "react";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import { cn } from "@/lib/utils";
 import { Loader2, Sparkles, FileCode2, FolderTree } from "lucide-react";
-import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
-import { vscDarkPlus } from "react-syntax-highlighter/dist/esm/styles/prism";
+import { transform } from "@babel/standalone";
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "react-resizable-panels";
 
 export interface ChatMessage {
   id: string;
@@ -35,9 +39,41 @@ interface WebsiteBuilderWorkspaceProps {
   chatHistory: ChatMessage[];
 }
 
+const fileMarkerRegex = /^\/\/\s*File:\s*(.+)$/gm;
+const jsExtensions = [".js", ".jsx", ".ts", ".tsx"];
+const cssExtensions = [".css"];
+const jsonExtensions = [".json"];
+type BabelConfigEntry = string | [string, Record<string, unknown>];
+
 const parseWebsiteFiles = (code?: string): WorkspaceFile[] => {
   if (!code) return [];
 
+  const markers = [...code.matchAll(fileMarkerRegex)];
+  if (markers.length > 0) {
+    const files: WorkspaceFile[] = [];
+    markers.forEach((match, index) => {
+      const rawPath = match[1]?.trim();
+      if (!rawPath) return;
+      const start = (match.index ?? 0) + match[0].length;
+      const end =
+        index + 1 < markers.length
+          ? markers[index + 1].index ?? code.length
+          : code.length;
+      const rawContent = code.slice(start, end);
+      const normalizedContent = rawContent
+        .replace(/^\s*\r?\n/, "")
+        .replace(/\s*$/, "");
+
+      files.push({
+        id: rawPath,
+        name: rawPath,
+        content: normalizedContent,
+      });
+    });
+    return files;
+  }
+
+  // Fallback pour l'ancien format HTML unique
   const files: WorkspaceFile[] = [];
   let htmlContent = code;
 
@@ -45,7 +81,10 @@ const parseWebsiteFiles = (code?: string): WorkspaceFile[] => {
   const scriptMatch = code.match(/<script[^>]*>([\s\S]*?)<\/script>/i);
 
   if (styleMatch && styleMatch[0]) {
-    htmlContent = htmlContent.replace(styleMatch[0], "<link rel=\"stylesheet\" href=\"styles.css\">");
+    htmlContent = htmlContent.replace(
+      styleMatch[0],
+      "<link rel=\"stylesheet\" href=\"styles.css\">",
+    );
     files.push({
       id: "styles.css",
       name: "styles.css",
@@ -54,7 +93,10 @@ const parseWebsiteFiles = (code?: string): WorkspaceFile[] => {
   }
 
   if (scriptMatch && scriptMatch[0]) {
-    htmlContent = htmlContent.replace(scriptMatch[0], "<script src=\"script.js\"></script>");
+    htmlContent = htmlContent.replace(
+      scriptMatch[0],
+      "<script src=\"script.js\"></script>",
+    );
     files.push({
       id: "script.js",
       name: "script.js",
@@ -69,6 +111,399 @@ const parseWebsiteFiles = (code?: string): WorkspaceFile[] => {
   });
 
   return files;
+};
+
+const escapeHtml = (value: string) =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+
+const createErrorDocument = (message: string) => `<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Erreur de preview</title>
+    <style>
+      body {
+        margin: 0;
+        padding: 32px;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        background: #0f172a;
+        color: #f8fafc;
+      }
+      pre {
+        max-width: 960px;
+        width: 100%;
+        background: rgba(15, 23, 42, 0.75);
+        border: 1px solid rgba(148, 163, 184, 0.3);
+        border-radius: 16px;
+        padding: 24px;
+        white-space: pre-wrap;
+        word-break: break-word;
+        box-shadow: 0 20px 50px rgba(15, 23, 42, 0.5);
+      }
+    </style>
+  </head>
+  <body>
+    <pre>${escapeHtml(message)}</pre>
+  </body>
+</html>`;
+
+const createReactPreviewDocument = (
+  files: WorkspaceFile[],
+): { doc: string | null; error: string | null } => {
+  if (files.length === 0) {
+    return { doc: null, error: null };
+  }
+
+  const jsFiles = files.filter((file) =>
+    jsExtensions.some((ext) => file.name.toLowerCase().endsWith(ext)),
+  );
+  const cssFiles = files.filter((file) =>
+    cssExtensions.some((ext) => file.name.toLowerCase().endsWith(ext)),
+  );
+  const jsonFiles = files.filter((file) =>
+    jsonExtensions.some((ext) => file.name.toLowerCase().endsWith(ext)),
+  );
+
+  const entryFile =
+    jsFiles.find((file) => /src\/main\.(t|j)sx?$/.test(file.id)) ??
+    jsFiles.find((file) => /App\.(t|j)sx?$/.test(file.id)) ??
+    jsFiles[0];
+
+  if (!entryFile) {
+    return {
+      doc: null,
+      error:
+        "Impossible de déterminer le point d'entrée React (ex: src/main.jsx).",
+    };
+  }
+
+  try {
+    const moduleDefinitions: string[] = [];
+
+    for (const file of jsFiles) {
+      const isTypeScript = file.name.endsWith(".ts") || file.name.endsWith(".tsx");
+      const isTSX = file.name.endsWith(".tsx");
+      const presets: BabelConfigEntry[] = [];
+      if (isTypeScript) {
+        const tsPresetOptions: Record<string, unknown> = {
+          isTSX,
+          allExtensions: true,
+          allowDeclareFields: true,
+        };
+        presets.push(["typescript", tsPresetOptions]);
+      }
+      const reactPresetOptions: Record<string, unknown> = {
+        runtime: "automatic",
+        development: false,
+      };
+      presets.push(["react", reactPresetOptions]);
+
+      const plugins: BabelConfigEntry[] = [[
+        "transform-modules-commonjs",
+        { strictMode: false },
+      ]];
+
+      let compiled = "";
+      try {
+        const result = transform(file.content, {
+          filename: file.id,
+          presets,
+          plugins,
+          sourceType: "module",
+          compact: false,
+          retainLines: true,
+          babelrc: false,
+          configFile: false,
+        });
+        compiled = result.code ?? "";
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : String(error);
+        throw new Error(`Erreur Babel dans ${file.name}: ${message}`);
+      }
+
+      moduleDefinitions.push(
+        `define(${JSON.stringify(file.id)}, new Function("module", "exports", "require", ${JSON.stringify(compiled)}));`,
+      );
+    }
+
+    for (const file of cssFiles) {
+      const runtime = `const css = ${JSON.stringify(file.content)};\nif (typeof document !== "undefined") {\n  const style = document.createElement("style");\n  style.setAttribute("data-filename", ${JSON.stringify(file.name)});\n  style.textContent = css;\n  document.head.appendChild(style);\n}\nmodule.exports = css;`;
+      moduleDefinitions.push(
+        `define(${JSON.stringify(file.id)}, new Function("module", "exports", "require", ${JSON.stringify(runtime)}));`,
+      );
+    }
+
+    for (const file of jsonFiles) {
+      const jsonContent = file.content.trim();
+      if (!jsonContent) continue;
+      const runtime = `module.exports = ${jsonContent};`;
+      moduleDefinitions.push(
+        `define(${JSON.stringify(file.id)}, new Function("module", "exports", "require", ${JSON.stringify(runtime)}));`,
+      );
+    }
+
+    const runtimeLines = [
+      "(function() {",
+      "  const modules = Object.create(null);",
+      "  const factories = Object.create(null);",
+      "  const builtinFactories = {",
+      "    react: function() {",
+      "      if (!window.React) { throw new Error(\"React n'est pas chargé.\"); }",
+      "      if (!('default' in window.React)) { window.React.default = window.React; }",
+      "      return window.React;",
+      "    },",
+      "    \"react-dom\": function() {",
+      "      if (!window.ReactDOM) { throw new Error(\"ReactDOM n'est pas chargé.\"); }",
+      "      if (!('default' in window.ReactDOM)) { window.ReactDOM.default = window.ReactDOM; }",
+      "      return window.ReactDOM;",
+      "    },",
+      "    \"react-dom/client\": function() {",
+      "      if (!window.ReactDOM) { throw new Error(\"ReactDOM n'est pas chargé.\"); }",
+      "      if (!('default' in window.ReactDOM)) { window.ReactDOM.default = window.ReactDOM; }",
+      "      return window.ReactDOM;",
+      "    },",
+      "    \"react/jsx-runtime\": function() {",
+      "      if (!window.React) { throw new Error(\"React n'est pas chargé.\"); }",
+      "      function prepareProps(props, key) {",
+      "        if (key === undefined || key === null) {",
+      "          return props;",
+      "        }",
+      "        var target = props ? Object.assign({}, props) : {};",
+      "        target.key = key;",
+      "        return target;",
+      "      }",
+      "      function jsxFactory(type, props, key) {",
+      "        return window.React.createElement(type, prepareProps(props, key));",
+      "      }",
+      "      var runtime = {",
+      "        Fragment: window.React.Fragment,",
+      "        jsx: jsxFactory,",
+      "        jsxs: jsxFactory,",
+      "        jsxDEV: jsxFactory",
+      "      };",
+      "      runtime.default = runtime;",
+      "      return runtime;",
+      "    },",
+      "    \"react/jsx-dev-runtime\": function() {",
+      "      if (!window.React) { throw new Error(\"React n'est pas chargé.\"); }",
+      "      function prepareProps(props, key) {",
+      "        if (key === undefined || key === null) {",
+      "          return props;",
+      "        }",
+      "        var target = props ? Object.assign({}, props) : {};",
+      "        target.key = key;",
+      "        return target;",
+      "      }",
+      "      function jsxFactory(type, props, key) {",
+      "        return window.React.createElement(type, prepareProps(props, key));",
+      "      }",
+      "      var runtime = {",
+      "        Fragment: window.React.Fragment,",
+      "        jsx: jsxFactory,",
+      "        jsxs: jsxFactory,",
+      "        jsxDEV: jsxFactory",
+      "      };",
+      "      runtime.default = runtime;",
+      "      return runtime;",
+      "    }",
+      "  };",
+      "  function define(id, factory) {",
+      "    factories[id] = factory;",
+      "  }",
+      "  function hasFactory(id) {",
+      "    return Object.prototype.hasOwnProperty.call(factories, id);",
+      "  }",
+      "  function dirname(path) {",
+      "    var parts = path.split('/');",
+      "    parts.pop();",
+      "    return parts.join('/');",
+      "  }",
+      "  function normalize(path) {",
+      "    var segments = [];",
+      "    path.split('/').forEach(function(segment) {",
+      "      if (!segment || segment === '.') return;",
+      "      if (segment === '..') {",
+      "        segments.pop();",
+      "      } else {",
+      "        segments.push(segment);",
+      "      }",
+      "    });",
+      "    return segments.join('/');",
+      "  }",
+      "  function resolve(from, request) {",
+      "    if (builtinFactories[request]) {",
+      "      return request;",
+      "    }",
+      "    if (hasFactory(request)) {",
+      "      return request;",
+      "    }",
+      "    if (request.indexOf('.') !== 0) {",
+      "      return request;",
+      "    }",
+      "    var baseDir = dirname(from);",
+      "    var base = baseDir ? baseDir + '/' : '';",
+      "    var combined = normalize(base + request);",
+      "    var attempts = [",
+      "      combined,",
+      "      combined + '.js',",
+      "      combined + '.jsx',",
+      "      combined + '.ts',",
+      "      combined + '.tsx',",
+      "      combined + '.json',",
+      "      combined + '.css'",
+      "    ];",
+      "    for (var i = 0; i < attempts.length; i += 1) {",
+      "      var attempt = attempts[i];",
+      "      if (hasFactory(attempt) || builtinFactories[attempt]) {",
+      "        return attempt;",
+      "      }",
+      "    }",
+      "    var indexAttempts = [",
+      "      combined + '/index.js',",
+      "      combined + '/index.jsx',",
+      "      combined + '/index.ts',",
+      "      combined + '/index.tsx'",
+      "    ];",
+      "    for (var j = 0; j < indexAttempts.length; j += 1) {",
+      "      var indexAttempt = indexAttempts[j];",
+      "      if (hasFactory(indexAttempt)) {",
+      "        return indexAttempt;",
+      "      }",
+      "    }",
+      "    return null;",
+      "  }",
+      "  function createRequire(from) {",
+      "    return function(request) {",
+      "      var resolved = resolve(from, request);",
+      "      if (!resolved) {",
+      "        throw new Error('Module non trouvé: ' + request + ' (depuis ' + from + ')');",
+      "      }",
+      "      return load(resolved);",
+      "    };",
+      "  }",
+      "  function load(id) {",
+      "    if (builtinFactories[id]) {",
+      "      if (!modules[id]) {",
+      "        var value = builtinFactories[id]();",
+      "        modules[id] = { exports: value, initialized: true };",
+      "      }",
+      "      return modules[id].exports;",
+      "    }",
+      "    var cached = modules[id];",
+      "    if (cached && cached.initialized) {",
+      "      return cached.exports;",
+      "    }",
+      "    var factory = factories[id];",
+      "    if (!factory) {",
+      "      throw new Error('Module non trouvé: ' + id);",
+      "    }",
+      "    var module = { exports: {} };",
+      "    modules[id] = { exports: module.exports, initialized: true };",
+      "    factory(module, module.exports, createRequire(id));",
+      "    modules[id].exports = module.exports;",
+      "    return modules[id].exports;",
+      "  }",
+    ];
+
+    moduleDefinitions.forEach((definition) => {
+      runtimeLines.push(`  ${definition}`);
+    });
+
+    runtimeLines.push("", `  load(${JSON.stringify(entryFile.id)});`, "})();");
+
+
+    const runtimeScript = runtimeLines.join("\n");
+    const sanitizedRuntime = runtimeScript.replace(/<\/script>/g, "<\\/script>");
+
+    const doc = `<!DOCTYPE html>
+<html lang="fr">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Preview React</title>
+    <style>
+      * { box-sizing: border-box; }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        background: #f8fafc;
+        color: #0f172a;
+      }
+      #root { min-height: 100vh; }
+      #error-overlay {
+        display: none;
+        position: fixed;
+        inset: 0;
+        background: rgba(15, 23, 42, 0.92);
+        color: #f1f5f9;
+        padding: 32px;
+        font-size: 14px;
+        overflow: auto;
+        z-index: 9999;
+      }
+      #error-overlay pre {
+        white-space: pre-wrap;
+        word-break: break-word;
+        margin: 0;
+        font-family: 'Fira Code', 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <div id="error-overlay"><pre></pre></div>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script>
+      (function() {
+        var overlay = document.getElementById('error-overlay');
+        var pre = overlay ? overlay.querySelector('pre') : null;
+        function showError(message) {
+          if (!overlay || !pre) return;
+          overlay.style.display = 'block';
+          pre.textContent = message;
+        }
+        window.addEventListener('error', function(event) {
+          if (event && typeof event.preventDefault === 'function') {
+            event.preventDefault();
+          }
+          if (event?.error) {
+            showError(event.error.stack || event.error.message || String(event.error));
+          } else if (event?.message) {
+            showError(event.message);
+          }
+        });
+        window.addEventListener('unhandledrejection', function(event) {
+          if (event && typeof event.preventDefault === 'function') {
+            event.preventDefault();
+          }
+          if (event?.reason) {
+            showError(event.reason.stack || event.reason.message || String(event.reason));
+          }
+        });
+      })();
+    </script>
+    <script>${sanitizedRuntime}</script>
+  </body>
+</html>`;
+
+    return { doc, error: null };
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : "Erreur inconnue lors de la génération de la preview.";
+    return { doc: createErrorDocument(message), error: message };
+  }
 };
 
 const WorkspacePrompt = ({
@@ -152,17 +587,55 @@ const WebsiteBuilderWorkspace = ({
   result,
   chatHistory,
 }: WebsiteBuilderWorkspaceProps) => {
-  const files = useMemo(() => parseWebsiteFiles(result?.code), [result?.code]);
-  const [activeFileId, setActiveFileId] = useState<string>(files[0]?.id ?? "index.html");
+  const [files, setFiles] = useState<WorkspaceFile[]>([]);
+  const [activeFileId, setActiveFileId] = useState<string | null>(null);
   const [tabValue, setTabValue] = useState("preview");
 
   useEffect(() => {
-    if (files.length > 0) {
-      setActiveFileId(files[0].id);
+    const parsedFiles = parseWebsiteFiles(result?.code);
+    setFiles(parsedFiles);
+  }, [result?.code]);
+
+  useEffect(() => {
+    if (files.length === 0) {
+      setActiveFileId(null);
+      return;
     }
+
+    setActiveFileId((previous) => {
+      if (previous && files.some((file) => file.id === previous)) {
+        return previous;
+      }
+      return files[0]?.id ?? null;
+    });
   }, [files]);
 
-  const activeFile = files.find((file) => file.id === activeFileId);
+  useEffect(() => {
+    if (result?.code) {
+      setTabValue("preview");
+    }
+  }, [result?.code]);
+
+  const activeFile = activeFileId
+    ? files.find((file) => file.id === activeFileId)
+    : undefined;
+
+  const previewState = useMemo(() => createReactPreviewDocument(files), [files]);
+  const previewDoc = previewState.doc;
+  const previewError = previewState.error;
+
+  const handleFileContentChange = useCallback((fileId: string, newContent: string) => {
+    setFiles((current) =>
+      current.map((file) =>
+        file.id === fileId
+          ? {
+              ...file,
+              content: newContent,
+            }
+          : file,
+      ),
+    );
+  }, []);
 
   return (
     <div className="flex min-h-screen flex-col bg-background">
@@ -204,7 +677,7 @@ const WebsiteBuilderWorkspace = ({
                       "flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-sm transition",
                       activeFileId === file.id
                         ? "bg-primary/10 text-foreground"
-                        : "hover:bg-muted/60 text-muted-foreground"
+                        : "hover:bg-muted/60 text-muted-foreground",
                     )}
                   >
                     <FileCode2 className="h-4 w-4" />
@@ -216,80 +689,88 @@ const WebsiteBuilderWorkspace = ({
           </ScrollArea>
         </aside>
 
-        <section className="flex flex-1 flex-col">
-          <ScrollArea className="flex-1 px-6 py-6">
-            <div className="mx-auto flex w-full max-w-2xl flex-col gap-4">
-              {chatHistory.length === 0 ? (
-                <div className="rounded-2xl border border-dashed border-border/50 bg-background/80 p-6 text-center text-sm text-muted-foreground">
-                  Commencez la conversation en décrivant le site que vous souhaitez créer.
+        <ResizablePanelGroup direction="horizontal" className="flex flex-1 overflow-hidden">
+          <ResizablePanel defaultSize={60} minSize={40} className="flex flex-col">
+            <div className="flex flex-1 flex-col">
+              <ScrollArea className="flex-1 px-6 py-6">
+                <div className="mx-auto flex w-full max-w-2xl flex-col gap-4">
+                  {chatHistory.length === 0 ? (
+                    <div className="rounded-2xl border border-dashed border-border/50 bg-background/80 p-6 text-center text-sm text-muted-foreground">
+                      Commencez la conversation en décrivant le site que vous souhaitez créer.
+                    </div>
+                  ) : (
+                    chatHistory.map((message) => <MessageBubble key={message.id} message={message} />)
+                  )}
                 </div>
-              ) : (
-                chatHistory.map((message) => <MessageBubble key={message.id} message={message} />)
-              )}
-            </div>
-          </ScrollArea>
-          <div className="border-t border-border/40 bg-background/80 px-6 py-4">
-            <div className="mx-auto w-full max-w-2xl">
-              <WorkspacePrompt onSubmit={onSubmit} isLoading={isLoading} />
-            </div>
-          </div>
-        </section>
-
-        <aside className="hidden w-[420px] flex-col border-l border-border/40 bg-muted/10 xl:flex">
-          <Tabs value={tabValue} onValueChange={setTabValue} className="flex h-full flex-col">
-            <div className="border-b border-border/40 px-4 py-3">
-              <TabsList className="h-9 bg-background/80">
-                <TabsTrigger value="preview" className="text-xs">Preview</TabsTrigger>
-                <TabsTrigger value="code" className="text-xs">Code</TabsTrigger>
-              </TabsList>
-            </div>
-            <TabsContent value="preview" className="flex-1 px-4 pb-4">
-              <div className="h-full overflow-hidden rounded-xl border border-border/40 bg-white shadow-inner">
-                {result?.code ? (
-                  <iframe
-                    key={result.code}
-                    srcDoc={result.code}
-                    title="Preview du site généré"
-                    className="h-full w-full"
-                    sandbox="allow-scripts allow-pointer-lock allow-same-origin"
-                  />
-                ) : (
-                  <div className="flex h-full items-center justify-center px-6 text-center text-xs text-muted-foreground">
-                    La preview du site apparaîtra ici après génération.
-                  </div>
-                )}
+              </ScrollArea>
+              <div className="border-t border-border/40 bg-background/80 px-6 py-4">
+                <div className="mx-auto w-full max-w-2xl">
+                  <WorkspacePrompt onSubmit={onSubmit} isLoading={isLoading} />
+                </div>
               </div>
-            </TabsContent>
-            <TabsContent value="code" className="flex-1 px-4 pb-4">
-              <div className="flex h-full flex-col gap-3">
-                <div className="rounded-lg border border-border/40 bg-background/70 px-3 py-2 text-xs font-medium text-muted-foreground">
-                  {activeFile?.name ?? "Sélectionnez un fichier"}
-                </div>
-                <div className="flex-1 overflow-hidden rounded-xl border border-border/40">
-                  {activeFile ? (
-                    <SyntaxHighlighter
-                      language={activeFile.name.endsWith(".css") ? "css" : activeFile.name.endsWith(".js") ? "javascript" : "html"}
-                      style={vscDarkPlus}
-                      showLineNumbers
-                      customStyle={{
-                        margin: 0,
-                        height: "100%",
-                        fontSize: "13px",
-                        background: "transparent",
-                      }}
-                    >
-                      {activeFile.content}
-                    </SyntaxHighlighter>
+            </div>
+          </ResizablePanel>
+          <ResizableHandle className="group hidden xl:flex w-4 cursor-col-resize items-center justify-center bg-transparent">
+            <div className="h-12 w-[2px] rounded-full bg-border transition-colors duration-200 group-data-[resize-handle-active=true]:bg-primary" />
+          </ResizableHandle>
+          <ResizablePanel
+            defaultSize={40}
+            minSize={25}
+            className="hidden xl:flex flex-col border-l border-border/40 bg-muted/10"
+          >
+            <Tabs value={tabValue} onValueChange={setTabValue} className="flex h-full flex-col">
+              <div className="border-b border-border/40 px-4 py-3">
+                <TabsList className="h-9 bg-background/80">
+                  <TabsTrigger value="preview" className="text-xs">Preview</TabsTrigger>
+                  <TabsTrigger value="code" className="text-xs">Code</TabsTrigger>
+                </TabsList>
+              </div>
+              <TabsContent value="preview" className="flex h-full flex-col gap-3 px-4 pb-4">
+                <div className="flex-1 overflow-hidden rounded-xl border border-border/40 bg-white shadow-inner">
+                  {previewDoc ? (
+                    <iframe
+                      srcDoc={previewDoc}
+                      title="Preview du site généré"
+                      className="h-full w-full"
+                      sandbox="allow-scripts allow-pointer-lock allow-same-origin"
+                    />
                   ) : (
                     <div className="flex h-full items-center justify-center px-6 text-center text-xs text-muted-foreground">
-                      Générez un site pour consulter son code.
+                      Générez un projet React pour visualiser la preview interactive.
                     </div>
                   )}
                 </div>
-              </div>
-            </TabsContent>
-          </Tabs>
-        </aside>
+                {previewError ? (
+                  <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                    {previewError}
+                  </div>
+                ) : null}
+              </TabsContent>
+              <TabsContent value="code" className="flex h-full flex-col gap-3 px-4 pb-4">
+                <div className="rounded-lg border border-border/40 bg-background/70 px-3 py-2 text-xs font-medium text-muted-foreground">
+                  {activeFile?.name ?? "Sélectionnez un fichier"}
+                </div>
+                <div className="rounded-lg border border-dashed border-border/40 bg-background/60 px-3 py-2 text-[11px] text-muted-foreground">
+                  Modifiez le code ci-dessous pour personnaliser votre site. La preview se met à jour automatiquement.
+                </div>
+                <div className="flex-1 overflow-hidden rounded-xl border border-border/40 bg-background">
+                  {activeFile ? (
+                    <textarea
+                      value={activeFile.content}
+                      onChange={(event) => handleFileContentChange(activeFile.id, event.target.value)}
+                      className="h-full w-full resize-none border-0 bg-transparent p-4 font-mono text-xs text-foreground outline-none focus-visible:outline-none focus-visible:ring-0"
+                      spellCheck={false}
+                    />
+                  ) : (
+                    <div className="flex h-full items-center justify-center px-6 text-center text-xs text-muted-foreground">
+                      Générez un site pour consulter et modifier son code.
+                    </div>
+                  )}
+                </div>
+              </TabsContent>
+            </Tabs>
+          </ResizablePanel>
+        </ResizablePanelGroup>
       </div>
     </div>
   );

--- a/supabase/functions/generate-content/index.ts
+++ b/supabase/functions/generate-content/index.ts
@@ -31,29 +31,29 @@ serve(async (req) => {
         break;
       
       case 'website':
-        systemPrompt = `Tu es un expert en développement web. Génère un site web HTML/CSS/JavaScript complet et fonctionnel basé sur la demande de l'utilisateur.
-        
-IMPORTANT: Réponds UNIQUEMENT avec du code, sans markdown, sans explications. Structure ton code ainsi:
+        systemPrompt = `Tu es un expert en développement front-end spécialisé en React. Génère un projet React moderne (React 18) basé sur la demande de l'utilisateur.
 
-<!DOCTYPE html>
-<html lang="fr">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Mon Site</title>
-    <style>
-    /* Tout le CSS ici */
-    </style>
-</head>
-<body>
-    <!-- Contenu HTML -->
-    <script>
-    // Tout le JavaScript ici
-    </script>
-</body>
-</html>
+IMPORTANT: Réponds UNIQUEMENT avec du code, sans markdown, sans explications. Respecte strictement le format suivant en séparant chaque fichier par un en-tête:
 
-Crée un site moderne, responsive, et fonctionnel. N'ajoute aucun texte en dehors du code HTML.`;
+// File: package.json
+{ ... }
+
+// File: src/main.jsx
+// Code ici
+
+// File: src/App.jsx
+// Code ici
+
+// File: src/index.css
+/* Styles ici */
+
+RÈGLES INDISPENSABLES:
+- Fournis uniquement des fichiers utiles au projet React (package.json, index.html si nécessaire, fichiers dans src/, etc.).
+- Le point d'entrée doit être src/main.jsx (ou src/main.tsx) qui monte l'application sur un élément #root en utilisant ReactDOM.createRoot.
+- Utilise React avec le runtime classique ou automatique, mais assure-toi d'importer React et ReactDOM quand c'est requis.
+- Ajoute un fichier de styles globaux (src/index.css) et importe-le dans le point d'entrée.
+- N'utilise aucune dépendance externe autre que React et ReactDOM.
+- N'ajoute aucun texte ou explication en dehors du code et des séparateurs de fichiers.`;
         responseFormat = 'code';
         break;
       


### PR DESCRIPTION
## Summary
- update the website generation prompt so the backend asks for a structured React project instead of a single HTML page
- add @babel/standalone and a lightweight bundler to render generated React code inside the preview iframe while keeping styles/scripts in sync
- refresh the workspace UI with editable code panels and a resizable preview so users can tweak files and instantly see the result

## Testing
- npm run lint *(fails: repo already contains lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68de94ca61f48323a3b2b3b2059e9e6d