### PR TITLE
Add pawn bomb gameplay rule support

### DIFF
--- a/src/lib/gameGenerator.ts
+++ b/src/lib/gameGenerator.ts
@@ -587,7 +587,8 @@ const buildGameCode = (config: {
 
       objectiveList.innerHTML = CONFIG.objectives
         .map((objective, index) => {
-          const label = objective.replace(/^[^:]+:\s*/, '').trim();
+          const segments = objective.split(':');
+          const label = (segments.length > 1 ? segments.slice(1).join(':') : objective).trim();
           return '<span><strong>' + String(index + 1).padStart(2, '0') + '</strong>' + label + '</span>';
         })
         .join('');
@@ -1000,8 +1001,19 @@ export const generateGameBlueprint = (
   const trimmedTitle = sanitizeSentence(brief.title);
   const trimmedTheme = sanitizeSentence(brief.theme);
   const trimmedDescription = sanitizeSentence(brief.description);
+  const haystack = `${trimmedTitle} ${trimmedTheme} ${trimmedDescription}`.toLowerCase();
+  const hasPawnBombMechanic =
+    (/(^|[^a-z])(pion|pawn)s?([^a-z]|$)/.test(haystack)) && /(bomb|bombe)/.test(haystack);
 
   const keywords = extractKeywords(trimmedDescription || trimmedTheme || trimmedTitle);
+  if (hasPawnBombMechanic) {
+    const bombKeywords = ["bombes", "explosion", "detonateurs"];
+    for (const keyword of bombKeywords) {
+      if (!keywords.includes(keyword)) {
+        keywords.push(keyword);
+      }
+    }
+  }
 
   const defaultTitle = keywords.length > 0 ? toTitleCase(keywords.slice(0, 2).join(" ")) : "Prototype IA";
   const title = trimmedTitle || defaultTitle;
@@ -1017,18 +1029,66 @@ export const generateGameBlueprint = (
   const enemyLabels = extractFeatureLabels(trimmedDescription, enemyPattern, keywords.slice(0, 3).map(toTitleCase));
   const companionLabels = extractFeatureLabels(trimmedDescription, friendPattern, keywords.slice(3, 6).map(toTitleCase));
 
-  const objectives = buildObjectives(trimmedDescription, [
+  let objectives = buildObjectives(trimmedDescription, [
     "Boucle principale : Explorer l'espace de jeu généré",
     "Progression : Intégrer vos directives pour enrichir le gameplay",
     "Ambiance : Expérience immersive rendue en WebGL",
   ]);
 
-  const collectibles = buildCollectibles(objectives, keywords.length > 0 ? keywords : ["artefacts", "fragments", "souvenirs"]);
+  if (hasPawnBombMechanic) {
+    const bombObjective =
+      "Boucle offensive : Poser des bombes tactiques avec le pion et contrôler leurs réactions en chaîne";
+    objectives = [bombObjective, ...objectives].slice(0, 3);
+  }
 
-  const assets = buildAssets(keywords, enemyLabels, companionLabels, objectives);
+  let collectibles = buildCollectibles(
+    objectives,
+    keywords.length > 0 ? keywords : ["artefacts", "fragments", "souvenirs"],
+  );
+
+  if (hasPawnBombMechanic) {
+    const bombCollectibles = ["Détonateurs calibrés", "Charges amplificatrices"];
+    for (let index = bombCollectibles.length - 1; index >= 0; index--) {
+      const collectible = bombCollectibles[index];
+      if (!collectibles.some((item) => item.toLowerCase().includes(collectible.toLowerCase()))) {
+        collectibles.unshift(collectible);
+      }
+    }
+
+    const seen = new Set<string>();
+    const uniqueCollectibles: string[] = [];
+    for (const collectible of collectibles) {
+      const key = collectible.toLowerCase();
+      if (seen.has(key)) continue;
+      seen.add(key);
+      uniqueCollectibles.push(collectible);
+      if (uniqueCollectibles.length >= 6) break;
+    }
+    collectibles = uniqueCollectibles;
+  }
+
+  let assets = buildAssets(keywords, enemyLabels, companionLabels, objectives);
+  if (hasPawnBombMechanic) {
+    const bombSources = getAssetSources(
+      "Bombes tactiques",
+      "Objet interactif",
+      ["bombes", "explosion", "detonateur"],
+    );
+    assets = [
+      {
+        id: nanoid(),
+        name: "Module Bombardier du pion",
+        category: "Objet interactif",
+        description:
+          "Gestion du placement, du compte à rebours et des effets visuels/sonores des bombes déposées par le pion.",
+        sources: bombSources,
+      },
+      ...assets,
+    ];
+  }
   const assetBankHighlights = summarizeAssetBanks(assets);
   const selectedAssetIds = assets.slice(0, 3).map((asset) => asset.id);
-  const updates = buildUpdates(
+  let updates = buildUpdates(
     theme,
     environment,
     enemyLabels,
@@ -1038,8 +1098,19 @@ export const generateGameBlueprint = (
     assetBankHighlights
   );
 
-  const descriptionFallback = trimmedDescription ||
+  if (hasPawnBombMechanic) {
+    updates = [
+      "Mécanique signature : le pion déploie des bombes temporisées capables de déclencher des réactions en chaîne.",
+      ...updates,
+    ];
+  }
+
+  const descriptionFallback =
+    trimmedDescription ||
     "Prototype généré automatiquement à partir de votre brief pour démonstration immédiate.";
+  const elevatorPitch = hasPawnBombMechanic
+    ? `${descriptionFallback} Le pion dispose d'un arsenal de bombes à retardement pour contrôler l'espace de jeu.`
+    : descriptionFallback;
 
   const code = buildGameCode({
     title,
@@ -1049,7 +1120,7 @@ export const generateGameBlueprint = (
     enemies: enemyLabels,
     collectibles,
     palette,
-    description: descriptionFallback,
+    description: elevatorPitch,
     keywords: keywords.length > 0 ? keywords : ["création", "monde", "action"],
   });
 
@@ -1059,7 +1130,13 @@ export const generateGameBlueprint = (
 
   const assetSourceSummary = assetBankHighlights.slice(0, 2).join(" & ");
 
-  const assistantMessage = `${directive}. ${title} vous plonge dans ${environment.toLowerCase()}. Objectifs clés : ${objectives
+  const mechanicsNote = hasPawnBombMechanic
+    ? "Mécanique spéciale : le pion orchestre un arsenal de bombes à retardement avec réactions en chaîne."
+    : "";
+
+  const assistantMessage = `${directive}. ${title} vous plonge dans ${environment.toLowerCase()}. ${
+    mechanicsNote ? `${mechanicsNote} ` : ""
+  }Objectifs clés : ${objectives
     .map((objective) => objective.replace(/^[^:]+:\s*/, ""))
     .join(" / ")}. Palette utilisée : ${palette.join(
     " → "
@@ -1073,7 +1150,7 @@ export const generateGameBlueprint = (
     summary: {
       title,
       theme,
-      elevatorPitch: descriptionFallback,
+      elevatorPitch,
       objectives,
       environment,
     },

--- a/supabase/functions/generate-content/index.ts
+++ b/supabase/functions/generate-content/index.ts
@@ -32,6 +32,8 @@ serve(async (req) => {
 
   try {
     const { prompt, category, kenneyPacks, mode, references } = await req.json();
+    const promptText = typeof prompt === 'string' ? prompt : '';
+    const normalizedPrompt = promptText.toLowerCase();
     const referenceCount = Array.isArray(references?.images) ? references.images.length : 0;
     console.log(
       `Génération pour catégorie: ${category}, mode: ${mode ?? 'default'}, références: ${referenceCount}, prompt: ${prompt}`,
@@ -157,9 +159,11 @@ RÈGLES INDISPENSABLES:
         responseFormat = 'code';
         break;
       
-      case 'game':
+      case 'game': {
         const supabaseUrl = Deno.env.get('SUPABASE_URL') || '';
         const proxyBase = supabaseUrl ? `${supabaseUrl}/functions/v1/proxy-asset?url=` : '';
+        const hasPawnBombMechanic =
+          (/(^|[^a-z])(pion|pawn)s?([^a-z]|$)/.test(normalizedPrompt)) && /(bomb|bombe)/.test(normalizedPrompt);
         let gameSystemPrompt = `Tu es un expert en développement de jeux vidéo HTML5/Canvas avec 10+ ans d'expérience en game design, physique 2D/3D, et optimisation de performance. Tu dois créer des jeux COMPLETS, JOUABLES et PROFESSIONNELS.
 
 ANALYSE DU BESOIN:
@@ -242,6 +246,20 @@ RÈGLES ESSENTIELLES:
 - Ajoute un système de sauvegarde des scores (localStorage)
 - NE génère PAS un prototype minimal, crée un JEU COMPLET`;
 
+        if (hasPawnBombMechanic) {
+          gameSystemPrompt += `
+
+RÈGLE PERSONNALISÉE : Pion pose des bombes
+- Le protagoniste principal est un pion (vue top-down ou isométrique) capable de se déplacer librement sur une grille.
+- Implémente une action de pose de bombes (touche Espace/clavier et bouton tactile dédié) avec retour visuel et sonore.
+- Chaque bombe reste active ~2 secondes avant d'exploser en croix (haut/bas/gauche/droite) avec une portée évolutive.
+- Les explosions détruisent les blocs fragiles, déclenchent des réactions en chaîne et éliminent les ennemis dans leur rayon.
+- Limite le nombre de bombes simultanées (ex: 3) et affiche un indicateur d'inventaire avec recharge progressive.
+- Prévois des bonus qui augmentent la portée, la vitesse du pion ou le stock de bombes, ainsi qu'un système de combo basé sur les éliminations.
+- Protège le pion d'une explosion fraîchement posée via une invulnérabilité courte pour éviter les auto-destructions injustes.
+- Ajoute des particules, un son d'amorçage, une alerte lumineuse avant l'explosion et une légère secousse d'écran pour renforcer l'impact.`;
+        }
+
         // Si des packs Kenney sont sélectionnés, ajouter les instructions pour les utiliser
         if (kenneyPacks && Array.isArray(kenneyPacks) && kenneyPacks.length > 0) {
           gameSystemPrompt += `
@@ -306,6 +324,7 @@ UTILISE CES ASSETS RÉELS dans ton jeu au lieu de dessiner des formes basiques!`
         systemPrompt = gameSystemPrompt;
         responseFormat = 'code';
         break;
+      }
       
       case 'music':
         systemPrompt = `Tu es un expert en composition musicale. Décris précisément comment créer la musique demandée:


### PR DESCRIPTION
## Summary
- detect pawn bomb mechanics in the game blueprint to tailor objectives, collectibles, assets, updates, and assistant messaging
- adjust the generated HUD setup to derive objective labels without regex escapes
- extend the game edge function prompt with a custom "Pion pose des bombes" rule when the prompt requests a pawn that plants bombs

## Testing
- npm run lint *(fails: existing lint issues in untouched files)*

------
https://chatgpt.com/codex/tasks/task_e_68e091c5462c8323ac19e156d97d3fa9